### PR TITLE
IO-163: Add new permission for user who can configure certificates

### DIFF
--- a/certificate.php
+++ b/certificate.php
@@ -152,5 +152,18 @@ function certificate_civicrm_navigationMenu(&$menu) {
     'label' => E::ts('Certificates'),
     'name' => 'compu-configure-certificate',
     'url' => 'civicrm/admin/certificates',
+    'permission' => 'configure certificates'
   ));
+}
+
+/**
+ * Implements hook_civicrm_permission().
+ * 
+ * Declare permissions used by the extension
+ */
+function certificate_civicrm_permission(&$permissions) {
+  $permissions['configure certificates'] = [
+    ts('CiviCRM: configure certificates'),
+    ts('User can configure which message templates can be downloaded as certificates.')
+  ];
 }

--- a/xml/Menu/certificate.xml
+++ b/xml/Menu/certificate.xml
@@ -4,19 +4,19 @@
     <path>civicrm/admin/certificates/add</path>
     <page_callback>CRM_Certificate_Form_CertificateConfigure</page_callback>
     <title>CertificateConfigure</title>
-    <access_arguments>access CiviCRM</access_arguments>
+    <access_arguments>configure certificates</access_arguments>
   </item>
   <item>
     <path>civicrm/admin/certificates/delete</path>
     <page_callback>CRM_Certificate_Form_CertificateConfigureDelete</page_callback>
     <title>Delete Certificate Configuration</title>
     <skipBreadCrumb>false</skipBreadCrumb>
-    <access_arguments>administer CiviCRM;configure certificates</access_arguments>
+    <access_arguments>configure certificates</access_arguments>
   </item>
   <item>
     <path>civicrm/admin/certificates</path>
     <page_callback>CRM_Certificate_Page_ConfigureCertificate</page_callback>
     <title>ConfigureCertificate</title>
-    <access_arguments>access CiviCRM</access_arguments>
+    <access_arguments>configure certificates</access_arguments>
   </item>
 </menu>


### PR DESCRIPTION
## Overview
Add new permission `configure certificates` that an administrator can grant to users who can configure certificates, this permission is required for certificate pages and menu