### PR TITLE
IO-178: Update styles to bootstrap

### DIFF
--- a/CRM/Certificate/Enum/CertificateType.php
+++ b/CRM/Certificate/Enum/CertificateType.php
@@ -19,7 +19,7 @@ class CRM_Certificate_Enum_CertificateType {
    */
   public static function getOptions() {
     return array(
-      ''  => E::ts('- select -'),
+      ''  => E::ts('- Select -'),
       self::CASES   => E::ts('Cases')
     );
   }

--- a/CRM/Certificate/Form/CertificateConfigure.php
+++ b/CRM/Certificate/Form/CertificateConfigure.php
@@ -18,14 +18,20 @@ class CRM_Certificate_Form_CertificateConfigure extends CRM_Core_Form {
     }
 
     $this->setTitle($titlePrefix . ' Certificate Configuration');
+    $url = CRM_Utils_System::url('civicrm/admin/certificates', 'reset=1');
+    $session = CRM_Core_Session::singleton();
+    $session->replaceUserContext($url);
   }
 
   public function buildQuickForm() {
     $this->add(
       'text',
       'name',
-      'Certificate Name',
-      NULL,
+      ts('Certificate Name'),
+      [
+        'placeholder' => ts('Certificate Name'),
+        'class' => 'form-control'
+      ],
       TRUE
     );
 
@@ -34,14 +40,18 @@ class CRM_Certificate_Form_CertificateConfigure extends CRM_Core_Form {
       'type',
       ts('Type'),
       CRM_Certificate_Enum_CertificateType::getOptions(),
-      TRUE
+      TRUE,
+      ['class' => 'form-control']
     );
 
     $this->add(
       'text',
       'linked_to',
       ts('Linked to'),
-      ['placeholder' => E::ts('- select type -'), 'disabled'],
+      [
+        'placeholder' => E::ts('- Select Type -'), 'disabled',
+        'class' => 'form-control'
+      ],
       TRUE
     );
 
@@ -56,14 +66,19 @@ class CRM_Certificate_Form_CertificateConfigure extends CRM_Core_Form {
         ],
         'label_field' => "msg_title",
         "search_field" => "msg_title"
-      ]
+      ],
+      'class' => 'form-control'
     ], true);
 
     $this->add(
       'text',
       'statuses',
       ts('Status'),
-      ['placeholder' => E::ts('- select linked to -'), 'disabled'],
+      [
+        'placeholder' => E::ts('- Select Status -'),
+        'disabled',
+        'class' => 'form-control'
+      ],
       TRUE
     );
 
@@ -71,11 +86,12 @@ class CRM_Certificate_Form_CertificateConfigure extends CRM_Core_Form {
       array(
         'type' => 'submit',
         'name' => E::ts('Save'),
-        'isDefault' => TRUE,
+        'isDefault' => TRUE
       ),
       array(
         'type' => 'cancel',
-        'name' => E::ts('Cancel')
+        'name' => E::ts('Cancel'),
+        'class' => 'btn-secondary-outline'
       ),
     ));
 

--- a/css/style.css
+++ b/css/style.css
@@ -1,0 +1,9 @@
+div.certificate__action-link {
+  margin-bottom: 20px;
+}
+.crm-ajax-container #bootstrap-theme > .certificate__create-form-panel.panel{
+  box-shadow: none;
+}
+.crm-ajax-container #bootstrap-theme > .certificate__create-form-panel.panel > div.panel-body {
+  border-top: unset;
+}

--- a/templates/CRM/Certificate/Form/CertificateConfigure.tpl
+++ b/templates/CRM/Certificate/Form/CertificateConfigure.tpl
@@ -1,19 +1,24 @@
-<div class="crm-block crm-form-block crm-uf-field-form-block">
-  {* HEADER *}
+{crmStyle ext=uk.co.compucorp.certificate file=css/style.css}
 
-  <table class="form-layout-compressed">
-    {foreach from=$elementNames item=elementName}
-    <tr class="crm-uf-field-form-block-field_name">
-      <td class="label">{$form.$elementName.label}</td>
-      <td>{$form.$elementName.html}</td>
-    </tr>
-    {/foreach}
-  </table>
+<div id="bootstrap-theme">
+  <div class="panel panel-default certificate__create-form-panel"">
+    <div class=" panel-body">
+    <div class="form-hoizontal">
+      {foreach from=$elementNames item=elementName}
+      <div class="form-group row">
+        <label class="col-sm-2 control-label">{$form.$elementName.label}</label>
+        <div class="col-sm-7 col-md-5">
+          {$form.$elementName.html}
+        </div>
+      </div>
+      {/foreach}
+    </div>
+  </div>
 
-  {* FOOTER *}
-  <div class="crm-submit-buttons">
+  <div class="crm-submit-buttons panel-footer">
     {include file="CRM/common/formButtons.tpl" location="bottom"}
   </div>
+</div>
 </div>
 
 <script language="javascript" type="text/javascript">

--- a/templates/CRM/Certificate/Form/CertificateConfigureDelete.tpl
+++ b/templates/CRM/Certificate/Form/CertificateConfigureDelete.tpl
@@ -1,9 +1,7 @@
-<div class="crm-block crm-form-block">
-  <div class="form-item">
-    <div class="messages status no-popup">
-      <div class="crm-i fa-info-circle"></div>
-      {ts}Are you sure you would like to delete?{/ts}
-    </div>
+<div id="bootstrap-theme">
+  <div class="alert alert-warning">
+    <i class="fa fa-info-circle"></i>
+    {ts}Are you sure you would like to delete?{/ts}
   </div>
   <div class="crm-submit-buttons">
     {include file="CRM/common/formButtons.tpl" location="bottom"}

--- a/templates/CRM/Certificate/Page/ConfigureCertificate.tpl
+++ b/templates/CRM/Certificate/Page/ConfigureCertificate.tpl
@@ -1,12 +1,16 @@
-<div class="crm-content-block crm-block">
-  <div class="action-link">
-    <a href="/civicrm/admin/certificates/add?reset=1" class="button crm-popup"><span><i class="crm-i fa-plus-circle"
-          aria-hidden="true"></i> {ts}New{/ts}</span></a>
+{crmStyle ext=uk.co.compucorp.certificate file=css/style.css}
+
+<div id="bootstrap-theme">
+  <div class="certificate__action-link">
+    <a href="/civicrm/admin/certificates/add?reset=1" class="btn btn-primary crm-popup">
+      <span class="btn-icon"><i class="fa fa-plus"></i></span> {ts}New Certificate{/ts}
+    </a>
   </div>
-  {include file="CRM/common/enableDisableApi.tpl"}
-  {include file="CRM/common/jsortable.tpl"}
-  <div id="all">
-    <table class="row-highlight">
+
+  <div class="panel panel-default">
+    {include file="CRM/common/enableDisableApi.tpl"}
+    {include file="CRM/common/jsortable.tpl"}
+    <table class="table">
       <thead>
         <tr>
           <th id="sortable">{ts}Certificate Name{/ts}</th>


### PR DESCRIPTION
## Overview
Update pages and forms to use bootstrap markups and css elements 

## Before
![bootstrap-before](https://user-images.githubusercontent.com/85277674/126343306-0dc79c7a-75a7-4535-91aa-199c4d1ede06.gif)


## After
![bootstrap-after-2](https://user-images.githubusercontent.com/85277674/126459618-03c65154-9023-41a4-8c95-9122a3454f12.gif)

![image](https://user-images.githubusercontent.com/85277674/126460841-93623317-4097-4143-a283-41e2d8a83106.png)


## Comments
Couldn't find a compatible botstrap style to replace class `crm-submit-buttons`, also class `crm-popup` was not replaced as it is used also by CiviCRM javascript
