### PR TITLE
IO-163: Change permision name to CompuCertificate

### DIFF
--- a/certificate.php
+++ b/certificate.php
@@ -163,7 +163,7 @@ function certificate_civicrm_navigationMenu(&$menu) {
  */
 function certificate_civicrm_permission(&$permissions) {
   $permissions['configure certificates'] = [
-    ts('CiviCRM: configure certificates'),
+    ts('CompuCertificate: configure certificates'),
     ts('User can configure which message templates can be downloaded as certificates.')
   ];
 }


### PR DESCRIPTION
## Overview
This PR updates the `configure certificate` permission name to begin with `CompuCertificate`  instead of `CiviCRM` to enable users to identify it is coming from the extension
