### PR TITLE
IO-209: Prevent duplicate certificate name

### DIFF
--- a/CRM/Certificate/Form/CertificateConfigure.php
+++ b/CRM/Certificate/Form/CertificateConfigure.php
@@ -211,6 +211,8 @@ class CRM_Certificate_Form_CertificateConfigure extends CRM_Core_Form {
   public function certificateRule($values) {
     $errors = [];
 
+    $this->validateCertificateName($values, $errors);
+
     // only validate statuses and linked_to if the certificate is attached to cases.
     if ($values['type'] != CRM_Certificate_Enum_CertificateType::CASES) {
       return $errors;
@@ -234,6 +236,19 @@ class CRM_Certificate_Form_CertificateConfigure extends CRM_Core_Form {
 
     if (empty($values['statuses'])) {
       $errors['statuses'] = ts('The status field is required');
+    }
+  }
+
+  /**
+   * Validates certificate name is unique.
+   *
+   * @param array $values
+   * @param array $errors
+   */
+  public function validateCertificateName($values, &$errors) {
+    $certificateService = new CRM_Certificate_Service_Certificate();
+    if ($certificateService->certificateNameExist($values['name'], $this->_id)) {
+      $errors['name'] = ts('The certificate name already exists');
     }
   }
 

--- a/CRM/Certificate/Service/Certificate.php
+++ b/CRM/Certificate/Service/Certificate.php
@@ -122,4 +122,30 @@ class CRM_Certificate_Service_Certificate {
     $optionsCondition[] = "cs.status_id in $statuses";
   }
 
+  /**
+   * Checks that a certificate name already exists or not.
+   *
+   * @param string $name
+   *  The certificate name to check.
+   * @param array $exclude
+   *  Array of certificate ids to exclude from the check.
+   *
+   * @return bool
+   *   true if the certificate name exists,
+   *   false otherwise.
+   */
+  public function certificateNameExist($name, $exclude = []) {
+    $query = CRM_Utils_SQL_Select::from(CRM_Certificate_DAO_CompuCertificate::$_tableName . ' ccc')
+      ->where('ccc.name = @name', ['name' => $name]);
+
+    if (!empty($exclude)) {
+      $excludedIds = sprintf('(%s)', implode(',', (array) $exclude));
+      $query->where('ccc.id not in ' . $excludedIds);
+    }
+
+    $certificateWithName = $query->execute()->fetchAll();
+
+    return !empty($certificateWithName);
+  }
+
 }


### PR DESCRIPTION
## Overview
This PR ensures the certificate's name is unique when creating a new certificate.

## Before
![name-b4](https://user-images.githubusercontent.com/85277674/130975544-cb8efe5c-0801-47e7-946c-243c128cf997.gif)

## After
![name-after](https://user-images.githubusercontent.com/85277674/130976274-b0b492bb-5b98-474d-8f5f-c093dae71344.gif)
