### PR TITLE
IO-206: Correct download page permission

### DIFF
--- a/xml/Menu/certificate.xml
+++ b/xml/Menu/certificate.xml
@@ -23,12 +23,12 @@
     <path>civicrm/certificates/case</path>
     <page_callback>CRM_Certificate_Page_CertificateDownload::downloadCaseCertificate</page_callback>
     <title>Download Certificate</title>
-    <access_arguments>access civicrm</access_arguments>
+    <access_arguments>access CiviCRM</access_arguments>
   </item>
   <item>
     <path>civicrm/certificates/event</path>
     <page_callback>CRM_Certificate_Page_CertificateDownload::downloadEventCertificate</page_callback>
     <title>Download Certificate</title>
-    <access_arguments>access civicrm</access_arguments>
+    <access_arguments>access CiviCRM</access_arguments>
   </item>
 </menu>


### PR DESCRIPTION
## Overview
This PR corrects the permission required to access the certificate download page

## Before
![access-denied-b4](https://user-images.githubusercontent.com/85277674/131095947-1a0b577a-e051-4910-a11a-4b5fb0041976.gif)

## After
![access-denied-after](https://user-images.githubusercontent.com/85277674/131095517-c07d87ac-1590-4231-ab20-6d30117fea05.gif)

