### PR TITLE
IO-305: Use pdf format applied to message template

### DIFF
--- a/CRM/Certificate/Service/CertificateDownloader.php
+++ b/CRM/Certificate/Service/CertificateDownloader.php
@@ -26,7 +26,7 @@ class CRM_Certificate_Service_CertificateDownloader {
       nl2br($content['html']),
       'certificate.pdf',
       FALSE,
-      ['orientation' => 'landscape']
+      $content["format"]
     );
     CRM_Utils_System::civiExit();
   }


### PR DESCRIPTION
## Overview
This PR allows certificate to be generated in the format that was applied to the message template

## Before
All downloaded certificates defaults to Landscape mode

## After
Certificates are now generated with respect to the format applied to their message template

