### PR TITLE
WHF-299: Remove the check for empty statuses and entity type

### DIFF
--- a/CRM/Certificate/Service/Certificate.php
+++ b/CRM/Certificate/Service/Certificate.php
@@ -30,12 +30,8 @@ class CRM_Certificate_Service_Certificate {
 
       $result['certificate'] = CRM_Certificate_BAO_CompuCertificate::create($params);
 
-      if (!empty($statuses)) {
-        $result['statuses'] = CRM_Certificate_BAO_CompuCertificateStatus::assignCertificateEntityStatuses($result['certificate'], $statuses);
-      }
-      if (!empty($entityTypes)) {
-        $result['entityTypes'] = CRM_Certificate_BAO_CompuCertificateEntityType::assignCertificateEntityTypes($result['certificate'], $entityTypes);
-      }
+      $result['statuses'] = CRM_Certificate_BAO_CompuCertificateStatus::assignCertificateEntityStatuses($result['certificate'], $statuses);
+      $result['entityTypes'] = CRM_Certificate_BAO_CompuCertificateEntityType::assignCertificateEntityTypes($result['certificate'], $entityTypes);
 
       $this->storeExtraValues($result, $values);
     });


### PR DESCRIPTION
## Overview
This PR removes the check for empty statuses and entity types, this is to allow entities with no strict requirement against empty statuses and entity types to be updated with empty values.

## Before
![whf-299-a](https://user-images.githubusercontent.com/85277674/146729024-158f2380-4005-4890-8d05-5f996239a935.gif)


## After
![whf-299-b](https://user-images.githubusercontent.com/85277674/146729064-00a0c51b-cfd9-4cee-90bf-f815e754001f.gif)
