### PR TITLE
WHF-300: Restrict user from creating certificate with empty linked_to or status field

### DIFF
--- a/CRM/Certificate/Enum/CertificateType.php
+++ b/CRM/Certificate/Enum/CertificateType.php
@@ -108,6 +108,7 @@ class CRM_Certificate_Enum_CertificateType {
         ],
         'select' => [
           'minimumInputLength' => 0,
+          'multiple' => TRUE,
         ],
       ],
       self::MEMBERSHIPS => [

--- a/CRM/Certificate/Exception/ConfigurationExistException.php
+++ b/CRM/Certificate/Exception/ConfigurationExistException.php
@@ -3,7 +3,7 @@
 class CRM_Certificate_Exception_ConfigurationExistException extends CRM_Core_Exception {
 
   public function __construct() {
-    parent::__construct('A certificate configuration exist for the entity that satisifes either the selected status or type');
+    parent::__construct('A certificate configuration exist for the entity that satisfies either the selected status or type');
   }
 
 }

--- a/CRM/Certificate/Form/CertificateConfigure.php
+++ b/CRM/Certificate/Form/CertificateConfigure.php
@@ -53,7 +53,7 @@ class CRM_Certificate_Form_CertificateConfigure extends CRM_Core_Form {
         1 => 'disabled',
         'class' => 'form-control',
       ],
-      FALSE
+      TRUE
     );
 
     $this->add(
@@ -92,7 +92,7 @@ class CRM_Certificate_Form_CertificateConfigure extends CRM_Core_Form {
         1 => 'disabled',
         'class' => 'form-control',
       ],
-      FALSE
+      TRUE
     );
 
     $this->addButtons([
@@ -219,16 +219,12 @@ class CRM_Certificate_Form_CertificateConfigure extends CRM_Core_Form {
     $errors = [];
 
     $this->validateCertificateName($values, $errors);
+    $this->validateLinkedToField($values, $errors);
+    $this->validateStatusesField($values, $errors);
 
-    // only validate statuses and linked_to if the certificate is attached to cases.
-    if ($values['type'] == CRM_Certificate_Enum_CertificateType::CASES) {
-      $this->validateLinkedToField($values, $errors);
-      $this->validateStatusesField($values, $errors);
-    }
-
-    // only validate linked_to if the certificate is attached to events.
-    if ($values['type'] == CRM_Certificate_Enum_CertificateType::EVENTS) {
-      $this->validateLinkedToField($values, $errors);
+    // The participant_type filed should only be validated for Event Certificate.
+    if ($values['types'] == CRM_Certificate_Enum_CertificateType::EVENTS) {
+      $this->validateParticipantTypeField($values, $errors);
     }
 
     return $errors ?: TRUE;
@@ -268,6 +264,18 @@ class CRM_Certificate_Form_CertificateConfigure extends CRM_Core_Form {
     $certificateService = new CRM_Certificate_Service_Certificate();
     if ($certificateService->certificateNameExist($values['name'], $this->_id)) {
       $errors['name'] = ts('The certificate name already exists');
+    }
+  }
+
+  /**
+   * Validates participant type field.
+   *
+   * @param array $values
+   * @param array $errors
+   */
+  public function validateParticipantTypeField($values, &$errors) {
+    if (empty($values['participant_type_id'])) {
+      $errors['participant_type_id'] = ts('The "Event role" field is required');
     }
   }
 

--- a/CRM/Certificate/Service/Certificate.php
+++ b/CRM/Certificate/Service/Certificate.php
@@ -148,7 +148,7 @@ class CRM_Certificate_Service_Certificate {
 
     // This is to avoid an entity having multiple certificate configuration,
     // i.e. in a case where a configuration that has linked_to 'all' and statuses for a specific status,
-    // and the user attepmts to create another configuration with linked_to for a specific type and statuses for 'all',
+    // and the user attempts to create another configuration with linked_to for a specific type and statuses for 'all',
     // then a ConfigurationExistException would be thrown.
     $conjuction = empty($values['linked_to']) || empty($values['statuses']) ? ' OR ' : ' AND ';
     $query = $query->where(implode($conjuction, $optionsCondition));

--- a/templates/CRM/Certificate/Form/CertificateConfigure.tpl
+++ b/templates/CRM/Certificate/Form/CertificateConfigure.tpl
@@ -33,23 +33,14 @@
 
   let toggleRequiredMarker = ($, val) => {
     if (val === TYPE_CASES) {
-      if (!$('.linked_to > label > span.crm-marker').length) {
-        $('.linked_to > label ').append('<span class="crm-marker" title="This field is required."> *</span>');
-      }
-      if (!$('.statuses > label > span.crm-marker').length) {
-        $('.statuses > label ').append('<span class="crm-marker" title="This field is required."> *</span>');
-      }
       $('.participant_type_id').hide()
     } else if (val === TYPE_EVENTS) {
-      if (!$('.linked_to > label > span.crm-marker').length) {
-        $('.linked_to > label ').append('<span class="crm-marker" title="This field is required."> *</span>');
+      if (!$('.participant_type_id > label > span.crm-marker').length) {
+        $('.participant_type_id > label ').append('<span class="crm-marker" title="This field is required."> *</span>');
       }
-      $('.statuses > label > span.crm-marker').remove()
       $('.participant_type_id').show()
     }
     else {
-      $('.linked_to > label > span.crm-marker').remove()
-      $('.statuses > label > span.crm-marker').remove()
       $('.participant_type_id').hide()
     }
   }


### PR DESCRIPTION
## Overview
Presently creating certificate configuration(Events and membership entity) with empty status and type is leading to unexpected scenarios, we've decided to restrict users from creating such certificate for now. This PR makes the linked_to and status field mandatory.

## Before
The linked_to and status fields are not mandatory and can be empty.

## After
The linked_to and status fields are mandatory and cannot be empty.
![hhhh](https://user-images.githubusercontent.com/85277674/148564800-55f3ab39-666d-47fa-9e5c-fd7207c6cabb.gif)
