### PR TITLE
WHFSPRT-243: Resolve issue with event token not resolved when summary is empty

### DIFF
--- a/CRM/Certificate/Token/Event.php
+++ b/CRM/Certificate/Token/Event.php
@@ -121,8 +121,8 @@ class CRM_Certificate_Token_Event extends CRM_Certificate_Token_AbstractCertific
     $tokens['start_date']['text/html'] = !empty($event['start_date']) ? CRM_Utils_Date::customFormat($event['start_date']) : '';
     $tokens['end_date']['text/html'] = !empty($event['end_date']) ? CRM_Utils_Date::customFormat($event['end_date']) : '';
     $tokens['event_type']['text/html'] = CRM_Core_PseudoConstant::getLabel('CRM_Event_BAO_Event', 'event_type_id', $event['event_type_id']);
-    $tokens['contact_phone']['text/html'] = $event['phone.phone'];
-    $tokens['contact_email']['text/html'] = $event['email.email'];
+    $tokens['contact_phone']['text/html'] = $event['phone.phone'] ?? '';
+    $tokens['contact_email']['text/html'] = $event['email.email'] ?? '';
 
     foreach (array_keys($this->entityTokens()) as $field) {
       if (!isset($tokens[$field])) {
@@ -132,7 +132,7 @@ class CRM_Certificate_Token_Event extends CRM_Certificate_Token_AbstractCertific
           $tokens[$field]['text/html'] = CRM_Core_BAO_CustomField::displayValue((string) $event[$customField], $id, $event['id']);
         }
         else {
-          $tokens[$field]['text/html'] = $event[$field];
+          $tokens[$field]['text/html'] = $event[$field] ?? '';
         }
       }
     }

--- a/tests/phpunit/CRM/Certificate/Service/CertificateEventGeneratorTest.php
+++ b/tests/phpunit/CRM/Certificate/Service/CertificateEventGeneratorTest.php
@@ -41,7 +41,7 @@ class CRM_Certificate_Service_EventCertificateGeneratorTest extends BaseHeadless
     $this->assertContains($participant['participant_source'], $result['html']);
   }
 
-  public function testGenerateCertificateWillResolveEventTokenWithEmptySummaryFields() {
+  public function testGenerateCertificateWillResolveEventTokenWithEmptySummaryField() {
     $content = $this->getMsgContent(
       "Summary: {certificate_event.summary} \n
       Start date: {certificate_event.start_date}"

--- a/tests/phpunit/CRM/Certificate/Service/CertificateEventGeneratorTest.php
+++ b/tests/phpunit/CRM/Certificate/Service/CertificateEventGeneratorTest.php
@@ -41,6 +41,34 @@ class CRM_Certificate_Service_EventCertificateGeneratorTest extends BaseHeadless
     $this->assertContains($participant['participant_source'], $result['html']);
   }
 
+  public function testGenerateCertificateWillResolveEventTokenWithEmptySummaryFields() {
+    $content = $this->getMsgContent(
+      "Summary: {certificate_event.summary} \n
+      Start date: {certificate_event.start_date}"
+    );
+    $template = CRM_Certificate_Test_Fabricator_MessageTemplate::fabricate($content);
+    $participant = $this->createParticipant();
+    $event = $participant["event"];
+
+    // Empty event summary and description.
+    $result = civicrm_api3("Event", "create", array_merge(
+      $event,
+      [
+        "summary" => "",
+        "description" => "",
+      ]
+    ));
+
+    $contact = $participant["contact"];
+
+    $generatorService = new CRM_Certificate_Service_CertificateGenerator();
+    $result = $generatorService->generate($template["id"], $contact["id"], $participant["id"]);
+
+    $this->assertContains($contact["display_name"], $result["html"]);
+    $this->assertContains($event["title"], $result["html"]);
+    $this->assertContains(CRM_Utils_Date::customFormat($event["start_date"]), $result["html"]);
+  }
+
   private function getMsgContent($extra = "") {
     return [
       'msg_html' => "Hello {contact.display_name} Subject is {certificate_event.title} {$extra}",


### PR DESCRIPTION
## Overview
This PR resolves the issue with event token not being resolved when summary field is empty.

## Before
![image](https://user-images.githubusercontent.com/85277674/157388376-1ca386c5-a7fe-4340-8d19-b053ad0d5040.png)

## After
![whf-event](https://user-images.githubusercontent.com/85277674/157389323-a0300912-8000-4260-89b8-04e98bd1d436.gif)
