### PR TITLE
MAE-885: Access getTokenCategories directly

### DIFF
--- a/CRM/Certificate/Token/AbstractCertificateToken.php
+++ b/CRM/Certificate/Token/AbstractCertificateToken.php
@@ -23,7 +23,7 @@ abstract class CRM_Certificate_Token_AbstractCertificateToken extends AbstractTo
    * @return bool
    */
   public function checkActive(\Civi\Token\TokenProcessor $processor) {
-    return !empty(array_intersect([static::TOKEN], $processor->context["hookTokenCategories"]));
+    return !empty(array_intersect([static::TOKEN], \CRM_Utils_Token::getTokenCategories()));
   }
 
   /**


### PR DESCRIPTION
## Overview
In CiviCRM 5.51.3 the `Civi\Token\TokenProcessor` class no longer caches token categories in `context`, so in this PR we access it directly from the `\CRM_Utils_Token::getTokenCategories()` function.