### PR TITLE
MAE-885: Use PHP8 container in test workflow 

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -40,9 +40,9 @@ jobs:
       - name: Download Certificate dependencies
         working-directory: ${{ env.CIVICRM_EXTENSIONS_DIR }}
         run: |
-          git clone --depth 1 https://github.com/civicrm/org.civicrm.shoreditch.git
-          git clone --depth 1 --no-single-branch https://github.com/compucorp/uk.co.compucorp.civicase.git
-          git clone --depth 1 https://github.com/compucorp/uk.co.compucorp.usermenu.git
+          git clone -b MAE-807-PHP8 --depth 1 https://github.com/civicrm/org.civicrm.shoreditch.git
+          git clone --depth 1 -b MAE-823-align-with-civi-5.51.3 https://github.com/compucorp/uk.co.compucorp.civicase.git
+          git clone -b MAE-847-php8 --depth 1 https://github.com/compucorp/uk.co.compucorp.usermenu.git
 
       - name: Switch Civicase Branch
         working-directory: ${{ env.CIVICRM_EXTENSIONS_DIR }}/uk.co.compucorp.civicase

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -6,7 +6,7 @@ jobs:
   run-unit-tests:
 
     runs-on: ubuntu-latest
-    container: compucorp/civicrm-buildkit:1.1.1-php7.2-chrome
+    container: compucorp/civicrm-buildkit:1.3.0-php8.0-chrome
 
     env:
       CIVICRM_EXTENSIONS_DIR: site/web/sites/all/modules/civicrm/tools/extensions
@@ -31,7 +31,7 @@ jobs:
         run : amp config:set --mysql_dsn=mysql://root:root@mysql:3306
 
       - name: Build Drupal site
-        run: civibuild create drupal-clean --civi-ver 5.35 --cms-ver 7.74 --web-root $GITHUB_WORKSPACE/site
+        run: civibuild create drupal-clean --civi-ver 5.51.3 --cms-ver 7.79 --web-root $GITHUB_WORKSPACE/site
 
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -33,6 +33,14 @@ jobs:
       - name: Build Drupal site
         run: civibuild create drupal-clean --civi-ver 5.51.3 --cms-ver 7.79 --web-root $GITHUB_WORKSPACE/site
 
+      - uses: compucorp/apply-patch@1.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          repo: compucorp/civicrm-core
+          version: 5.51.3
+          path: site/web/sites/all/modules/civicrm
+
       - uses: actions/checkout@v2
         with:
             path: ${{ env.CIVICRM_EXTENSIONS_DIR }}/uk.co.compucorp.certificate

--- a/CRM/Certificate/Test/Fabricator/CaseType.php
+++ b/CRM/Certificate/Test/Fabricator/CaseType.php
@@ -5,6 +5,15 @@
  */
 class CRM_Certificate_Test_Fabricator_CaseType {
 
+  /**
+   * Fabricates new CaseType entity.
+   *
+   * @param array $params
+   *   Case parameters.
+   *
+   * @return array
+   *   Values of newly created Case entity.
+   */
   public static function fabricate($params = []) {
     $params = array_merge(self::getDefaultParams(), $params);
     $result = civicrm_api3(
@@ -16,9 +25,13 @@ class CRM_Certificate_Test_Fabricator_CaseType {
     return array_shift($result['values']);
   }
 
+  /**
+   * Returns default Parameters.
+   *
+   * @var array
+   */
   public static function getDefaultParams() {
     $title = md5(mt_rand());
-    $activityTypes = md5(mt_rand());
     $activity = md5(mt_rand());
     return [
       'title' => $title,
@@ -28,7 +41,7 @@ class CRM_Certificate_Test_Fabricator_CaseType {
       'weight' => 100,
       'definition' => [
         'activityTypes' => [
-          ['name' => $activityTypes],
+          ['name' => 'Meeting'],
         ],
         'activitySets' => [
           [

--- a/CRM/Certificate/Token/AbstractCertificateToken.php
+++ b/CRM/Certificate/Token/AbstractCertificateToken.php
@@ -23,7 +23,7 @@ abstract class CRM_Certificate_Token_AbstractCertificateToken extends AbstractTo
    * @return bool
    */
   public function checkActive(\Civi\Token\TokenProcessor $processor) {
-    return !empty(array_intersect([static::TOKEN], $processor->context["hookTokenCategories"]));
+    return !empty(array_intersect([static::TOKEN], \CRM_Utils_Token::getTokenCategories()));
   }
 
   /**

--- a/tests/phpunit/BaseHeadlessTest.php
+++ b/tests/phpunit/BaseHeadlessTest.php
@@ -1,17 +1,61 @@
 <?php
 
+use Civi\Test;
 use Civi\Test\HeadlessInterface;
 use Civi\Test\TransactionalInterface;
 
+/**
+ * Base test class.
+ */
 abstract class BaseHeadlessTest extends PHPUnit_Framework_TestCase implements
     HeadlessInterface,
     TransactionalInterface {
 
+  /**
+   * {@inheritDoc}
+   */
   public function setUpHeadless() {
-    return \Civi\Test::headless()
+    return Test::headless()
       ->installMe(__DIR__)
       ->install(['uk.co.compucorp.civicase'])
       ->apply();
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function getMockBuilder($className) {
+    $mockBuilder = (new class($this, $className) extends PHPUnit_Framework_MockObject_MockBuilder {
+
+      /**
+       * {@inheritDoc}
+       */
+      public function getMock() {
+        static::setSupressedErrorHandler();
+
+        try {
+          return parent::getMock();
+        } finally {
+          restore_error_handler();
+        }
+      }
+
+      /**
+       * Supress depreciation warnings.
+       */
+      public static function setSupressedErrorHandler() {
+        $previousHandler = set_error_handler(function ($code, $description, $file = NULL, $line = NULL, $context = NULL) use (&$previousHandler) {
+          if ($code & E_DEPRECATED) {
+              return TRUE;
+          }
+
+            return $previousHandler($code, $description, $file, $line, $context);
+        });
+      }
+
+    });
+
+    return $mockBuilder;
   }
 
 }

--- a/tests/phpunit/CRM/Certificate/Token/CaseTest.php
+++ b/tests/phpunit/CRM/Certificate/Token/CaseTest.php
@@ -60,10 +60,14 @@ class CRM_Certificate_Token_CaseTest extends BaseHeadlessTest {
     $caseFields = array_merge(array_keys($caseTokenSubscriber::caseFields), [$activeToken]);
 
     $tokenValueEventMock->method('getTokenProcessor')->willReturn($tokenProcessorMock);
-    $tokenProcessorMock->method('getContextValues')->will($this->onConsecutiveCalls(
-      [$case['id']],
-      [array_shift($case['contact_id'])]
-    ));
+    $contextValues = [
+      'entityId' => [$case['id']],
+      'contactId' => [array_shift($case['contact_id'])],
+    ];
+
+    $tokenProcessorMock->method('getContextValues')->willReturnCallback(
+      fn ($context) => $contextValues[$context] ?? NULL
+    );
 
     $prefetchedTokens = $caseTokenSubscriber->prefetch($tokenValueEventMock);
 


### PR DESCRIPTION
## Overview
In this PR we updated the PHP version to 8.0 and the CiviCRM version to 5.51.3 in the test workflow, one of the significant errors that were reported is
`undefined array key "hookTokenCategories"` because in CiviCRM 5.51.3 the `Civi\Token\TokenProcessor` class no longer caches token categories in `context`, to resolve this we access it directly from the `\CRM_Utils_Token::getTokenCategories()` function.