### PR TITLE
FOSFAB-38: Allow empty start_date and end_date

### DIFF
--- a/CRM/Certificate/BAO/CompuCertificate.php
+++ b/CRM/Certificate/BAO/CompuCertificate.php
@@ -51,7 +51,6 @@ class CRM_Certificate_BAO_CompuCertificate extends CRM_Certificate_DAO_CompuCert
     $certificateBAO->joinAdd(['id', new CompuCertificateStatus(), 'certificate_id'], 'LEFT', 'cert_status');
     $certificateBAO->whereAdd('entity = ' . $entity);
     $certificateBAO->whereDateIsValid();
-    $certificateBAO->whereAdd('start_date IS NULL OR end_date IS NULL OR start_date = CURRENT_DATE OR end_date = CURRENT_DATE OR CURRENT_TIMESTAMP BETWEEN start_date AND end_date');
     $certificateBAO->selectAdd(self::$_tableName . '.id' . ' as certificate_id');
     $certificateBAO->find();
 
@@ -76,7 +75,7 @@ class CRM_Certificate_BAO_CompuCertificate extends CRM_Certificate_DAO_CompuCert
    * Add condition to ensure the certificate start_date and end_date is valid.
    */
   public function whereDateIsValid() {
-    $this->whereAdd('(start_date IS NULL OR end_date IS NULL OR start_date = CURRENT_DATE OR end_date = CURRENT_DATE OR CURRENT_TIMESTAMP BETWEEN start_date AND end_date)');
+    $this->whereAdd('(start_date IS NULL OR date(start_date) <= date(NOW())) AND (end_date IS NULL OR date(end_date) >= date(NOW()) )');
   }
 
 }

--- a/CRM/Certificate/Form/CertificateConfigure.php
+++ b/CRM/Certificate/Form/CertificateConfigure.php
@@ -103,8 +103,8 @@ class CRM_Certificate_Form_CertificateConfigure extends CRM_Core_Form {
       'start_date',
       ts('Start Date'),
       NULL,
-      TRUE,
-      ['minDate' => date('Y-m-d'), 'time' => FALSE]
+      FALSE,
+      ['time' => FALSE]
     );
 
     $this->add(
@@ -112,8 +112,8 @@ class CRM_Certificate_Form_CertificateConfigure extends CRM_Core_Form {
       'end_date',
       ts('End Date'),
       NULL,
-      TRUE,
-      ['minDate' => date('Y-m-d'), 'time' => FALSE]
+      FALSE,
+      ['time' => FALSE]
     );
 
     $this->add(
@@ -341,6 +341,11 @@ class CRM_Certificate_Form_CertificateConfigure extends CRM_Core_Form {
    * @param array $errors
    */
   public function validateDateField($values, &$errors) {
+    // Ignore validation if either of the dates are empty.
+    if (empty($values['end_date']) || empty($values['start_date'])) {
+      return;
+    }
+
     if (strtotime($values['end_date']) <= strtotime($values['start_date'])) {
       $errors['end_date'] = ts('End date field must be after start date');
     }

--- a/CRM/Certificate/Test/Helper/Certificate.php
+++ b/CRM/Certificate/Test/Helper/Certificate.php
@@ -1,0 +1,54 @@
+<?php
+
+trait CRM_Certificate_Test_Helper_Certificate {
+
+  public function provideCertificateDateData(): array {
+    return [
+      'start_date and end_date is null' => [
+        'start_date' => NULL,
+        'end_date' => NULL,
+        'valid' => TRUE,
+      ],
+      'start_date is null and end_date was 3 days ago' => [
+        'start_date' => NULL,
+        'end_date' => $this->getDate("- 3 days"),
+        'valid' => FALSE,
+      ],
+      'start_date is null and end_date is 3 days from now' => [
+        'start_date' => NULL,
+        'end_date' => $this->getDate("3 days"),
+        'valid' => TRUE,
+      ],
+      'start_date is 3 days from now and end_date is null' => [
+        'start_date' => $this->getDate("3 days"),
+        'end_date' => NULL,
+        'valid' => FALSE,
+      ],
+      'start_date was 3 days ago and end_date is null' => [
+        'start_date' => $this->getDate("- 3 days"),
+        'end_date' => NULL,
+        'valid' => TRUE,
+      ],
+      'start_date was 3 days ago and end_date is 10 days from now' => [
+        'start_date' => $this->getDate("- 3 days"),
+        'end_date' => $this->getDate("10 days"),
+        'valid' => TRUE,
+      ],
+      'start_date was 10 days ago and end_date is 3 days ago' => [
+        'start_date' => $this->getDate("- 10 days"),
+        'end_date' => $this->getDate("- 3 days"),
+        'valid' => FALSE,
+      ],
+      'start_date is 10 days from now and end_date is 20 days from now' => [
+        'start_date' => $this->getDate("10 days"),
+        'end_date' => $this->getDate("20 days"),
+        'valid' => FALSE,
+      ],
+    ];
+  }
+
+  public function getDate($from = "0 days") {
+    return date('Y-m-d', strtotime(date('Y-m-d') . " $from"));
+  }
+
+}

--- a/tests/phpunit/BaseHeadlessTest.php
+++ b/tests/phpunit/BaseHeadlessTest.php
@@ -14,8 +14,4 @@ abstract class BaseHeadlessTest extends PHPUnit_Framework_TestCase implements
       ->apply();
   }
 
-  public function getDate($from = "0 days") {
-    return date('Y-m-d', strtotime(date('Y-m-d') . " $from"));
-  }
-
 }

--- a/tests/phpunit/CRM/Certificate/Entity/CaseTest.php
+++ b/tests/phpunit/CRM/Certificate/Entity/CaseTest.php
@@ -8,6 +8,7 @@
 class CRM_Certificate_Entity_CaseTest extends BaseHeadlessTest {
 
   use CRM_Certificate_Test_Helper_Case;
+  use CRM_Certificate_Test_Helper_Certificate;
 
   /**
    * Test the appropraite types are returned
@@ -191,6 +192,28 @@ class CRM_Certificate_Entity_CaseTest extends BaseHeadlessTest {
     $expectedCasesId = array_column($validCertificate, "id");
     $avaliableCertificatesCaseId = array_column($avaliableCertificates, "case_id");
     $this->assertCount(0, array_diff($expectedCasesId, $avaliableCertificatesCaseId));
+  }
+
+  /**
+   * Test that only certificates wihthin the validitly period is returned.
+   *
+   * @param string $startDate
+   *  Validity start date.
+   * @param string $endDate
+   *  Validity end date.
+   * @param boolean $valid
+   *  If the date is considered valid.
+   *
+   * @dataProvider provideCertificateDateData
+   */
+  public function testCaseCertificatesValidityByDate($startDate, $endDate, $valid) {
+    $contact = CRM_Certificate_Test_Fabricator_Contact::fabricate();
+
+    $this->createCaseCertificate(['start_date' => $startDate, 'end_date' => $endDate, 'client_id' => $contact["id"]]);
+    $caseEntity = new CRM_Certificate_Entity_Case();
+    $avaliableCertificates = $caseEntity->getContactCertificates($contact["id"]);
+
+    $this->assertEquals(count($avaliableCertificates) > 0, $valid);
   }
 
   private function createCertificate($values = []) {

--- a/tests/phpunit/api/v3/CompuCertificate/GetcontactcertificatesTest.php
+++ b/tests/phpunit/api/v3/CompuCertificate/GetcontactcertificatesTest.php
@@ -14,6 +14,7 @@ class api_v3_CompuCertificate_GetcontactcertificatesTest extends BaseHeadlessTes
   use CRM_Certificate_Test_Helper_Event;
   use CRM_Certificate_Test_Helper_Session;
   use CRM_Certificate_Test_Helper_Membership;
+  use CRM_Certificate_Test_Helper_Certificate;
 
   /**
    * Holds logged in contact/case client id.
@@ -151,16 +152,25 @@ class api_v3_CompuCertificate_GetcontactcertificatesTest extends BaseHeadlessTes
   }
 
   /**
-   * Test that the api does not return expired memberships certificate .
+   * Test that the api does not return expired memberships certificate.
+   *
+   * @param string $startDate
+   *  Validity start date.
+   * @param string $endDate
+   *  Validity end date.
+   * @param boolean $valid
+   *  If the date is considered valid.
+   *
+   * @dataProvider provideCertificateDateData
    */
-  public function testExpiredMembershipCertficateIsNotReturnedForAPI() {
+  public function testExpiredMembershipCertficateIsNotReturnedForAPI($startDate, $endDate, $valid) {
     $membership = $this->createMembership();
     $this->createMembershipCertificate(
       [
         'linked_to' => [$membership['membership_type_id']],
         'statuses'  => [$membership['status_id']],
-        'start_date' => $this->getDate('- 15 days'),
-        'end_date' => $this->getDate('- 1 days'),
+        'start_date' => $startDate,
+        'end_date' => $endDate,
       ]
     );
 
@@ -170,20 +180,29 @@ class api_v3_CompuCertificate_GetcontactcertificatesTest extends BaseHeadlessTes
 
     $results = $this->callApiSuccess('CompuCertificate', 'getcontactcertificates', $param);
 
-    $this->assertEmpty($results['values']);
+    $this->assertEquals($results['count'] > 0, $valid);
   }
 
   /**
    * Test that the api does not return expired events certificate.
+   *
+   * @param string $startDate
+   *  Validity start date.
+   * @param string $endDate
+   *  Validity end date.
+   * @param boolean $valid
+   *  If the date is considered valid.
+   *
+   * @dataProvider provideCertificateDateData
    */
-  public function testExpiredEventCertficateIsNotReturnedForAPI() {
+  public function testExpiredEventCertficateIsNotReturnedForAPI($startDate, $endDate, $valid) {
     $participant = $this->createParticipant(['contact_id' => $this->client_id]);
     $this->createEventCertificate(
       [
         'linked_to' => [$participant['event_id']],
         'statuses'  => [$participant['participant_status_id']],
-        'start_date' => $this->getDate('- 15 days'),
-        'end_date' => $this->getDate('- 1 days'),
+        'start_date' => $startDate,
+        'end_date' => $endDate,
       ]
     );
 
@@ -191,17 +210,26 @@ class api_v3_CompuCertificate_GetcontactcertificatesTest extends BaseHeadlessTes
 
     $results = $this->callApiSuccess('CompuCertificate', 'getcontactcertificates', $param);
 
-    $this->assertEquals(0, $results['count']);
+    $this->assertEquals($results['count'] > 0, $valid);
   }
 
   /**
    * Test that the api does not return expired cases certificate.
+   *
+   * @param string $startDate
+   *  Validity start date.
+   * @param string $endDate
+   *  Validity end date.
+   * @param boolean $valid
+   *  If the date is considered valid.
+   *
+   * @dataProvider provideCertificateDateData
    */
-  public function testExpiredCaseCertficateIsNotReturnedForAPI() {
+  public function testExpiredCaseCertficateIsNotReturnedForAPI($startDate, $endDate, $valid) {
     $caseParam = [
       'client_id' => $this->client_id,
-      'start_date' => $this->getDate('- 15 days'),
-      'end_date' => $this->getDate('- 1 days'),
+      'start_date' => $startDate,
+      'end_date' => $endDate,
     ];
     $this->createCaseCertificate($caseParam);
 
@@ -209,7 +237,7 @@ class api_v3_CompuCertificate_GetcontactcertificatesTest extends BaseHeadlessTes
 
     $results = $this->callApiSuccess('CompuCertificate', 'getcontactcertificates', $param);
 
-    $this->assertEquals(0, $results['count']);
+    $this->assertEquals($results['count'] > 0, $valid);
   }
 
   public function tearDown() {


### PR DESCRIPTION
## Overview
This PR allows the start_date and the end_date fields for the certificate configuration to be empty. such that, If a start date is set, the certificate will begin on that date and will assume to be available forever. However, if an end date is set, it will only be available until the end date.

## Before
start_date and end_date fields are mandatory.
![llll](https://user-images.githubusercontent.com/85277674/212626294-dfc373a6-f099-42e7-9b37-9659107a559c.gif)

## After
start_date and end_date fields are optional.
![aaaa](https://user-images.githubusercontent.com/85277674/212625986-0d45bb81-2bcc-496d-a9fa-074c8e1c82c4.gif)


## Technical Details
The major change is replacing this condition:
```(start_date IS NULL OR end_date IS NULL OR start_date = CURRENT_DATE OR end_date = CURRENT_DATE OR CURRENT_TIMESTAMP BETWEEN start_date AND end_date)```

with

```(start_date IS NULL OR date(start_date) <= date(NOW())) AND (end_date IS NULL OR date(end_date) >= date(NOW()) )```