### PR TITLE
FOSFAB-43: Support single certificate configuration with multiple membership types

### DIFF
--- a/CRM/Certificate/Enum/CertificateType.php
+++ b/CRM/Certificate/Enum/CertificateType.php
@@ -72,7 +72,7 @@ class CRM_Certificate_Enum_CertificateType {
         ],
         'select' => [
           'minimumInputLength' => 0,
-          'multiple' => FALSE,
+          'multiple' => TRUE,
         ],
       ],
     ]);


### PR DESCRIPTION
## Overview
This PR adds support for single certificate configuration with multiple membership types

## Before
Single certificate configuration can only be used with a membership type.
![zzz1](https://user-images.githubusercontent.com/85277674/212852638-4cedaa92-245a-4477-9f4f-73f7b5663ec1.gif)

## After
Single certificate configuration can be used with multiple membership types.
![zzz](https://user-images.githubusercontent.com/85277674/212852442-e13a9d4c-69c5-4939-a61a-208ec35c4105.gif)
