### PR TITLE
FOSFAB-44: Add Endpoint to retrieve contact certificates by relationship

### DIFF
--- a/CRM/Certificate/Api/Wrapper/CompuCertificate.php
+++ b/CRM/Certificate/Api/Wrapper/CompuCertificate.php
@@ -10,6 +10,17 @@ use CRM_Certificate_Enum_CertificateType as CertificateType;
 class CRM_Certificate_Api_Wrapper_CompuCertificate implements API_Wrapper {
 
   /**
+   * Entities supported by the API.
+   *
+   * @var array
+   */
+  public const SUPPORTED_ENTITY_PARAMS = [
+    'case' => CertificateType::CASES,
+    'event' => CertificateType::EVENTS,
+    'membership' => CertificateType::MEMBERSHIPS,
+  ];
+
+  /**
    * Returns list of certificates accessible to loggedin user.
    *
    * @param array $params
@@ -19,46 +30,51 @@ class CRM_Certificate_Api_Wrapper_CompuCertificate implements API_Wrapper {
    *   Result with the list of certificates.
    */
   public function getContactCertificates(array $params) {
-    $loggedContactID = CRM_Core_Session::singleton()->getLoggedInContactID();
-    // If no contact_id is provided we default to the logged in contact ID.
-    $contactId = $params['contact_id'] ?? $loggedContactID;
+    $params = $this->setDefaultParams($params);
 
-    $certificates = [];
-
-    if (empty($contactId)) {
+    if (empty($params['contact_id'])) {
       return [];
     }
 
-    switch (TRUE) {
-      case empty($params['entity']):
-        $certificates = $this->getContactEntityCertificate(CertificateType::CASES, $contactId);
-        break;
-
-      case $params['entity'] === 'case':
-        $certificates = $this->getContactEntityCertificate(CertificateType::CASES, $contactId);
-        break;
-
-      case $params['entity'] === 'event':
-        $certificates = $this->getContactEntityCertificate(CertificateType::EVENTS, $contactId);
-        break;
-
-      case $params['entity'] === 'membership':
-        $certificates = $this->getContactEntityCertificate(CertificateType::MEMBERSHIPS, $contactId);
-        break;
-
-      default:
-        $certificates = [];
-        break;
+    $entity = CRM_Utils_Array::value($params['entity'], self::SUPPORTED_ENTITY_PARAMS);
+    if (!empty($entity)) {
+      $entity = CRM_Certificate_Entity_EntityFactory::create($entity);
+      return $entity->getContactCertificates($params['contact_id']);
     }
 
-    return $certificates;
+    return [];
   }
 
-  private function getContactEntityCertificate(int $entity, int $contactId) {
-    $entity = CRM_Certificate_Entity_EntityFactory::create($entity);
-    $certificates = $entity->getContactCertificates($contactId);
+  /**
+   * Returns list of certificates contact has access to based on relationship.
+   *
+   * @param array $params
+   *   Parameters array for the API call.
+   *
+   * @return array
+   *   Result with the list of certificates.
+   */
+  public function getRelationshipCertificates(array $params) {
+    $params = $this->setDefaultParams($params);
 
-    return $certificates;
+    if (empty($params['contact_id'])) {
+      return [];
+    }
+
+    $entity = CRM_Utils_Array::value($params['entity'], self::SUPPORTED_ENTITY_PARAMS);
+    if (!empty($entity)) {
+      $entity = CRM_Certificate_Entity_EntityFactory::create($entity);
+      return $entity->getRelationshipCertificates($params['contact_id']);
+    }
+
+    return [];
+  }
+
+  private function setDefaultParams($params) {
+    return array_merge([
+      'entity' => 'case',
+      'contact_id' => CRM_Core_Session::singleton()->getLoggedInContactID(),
+    ], $params);
   }
 
   /**

--- a/CRM/Certificate/BAO/CompuCertificate.php
+++ b/CRM/Certificate/BAO/CompuCertificate.php
@@ -1,9 +1,11 @@
 <?php
 
 use CRM_Certificate_ExtensionUtil as E;
+use CRM_Contact_BAO_Relationship as Relationship;
 use CRM_Certificate_Enum_DownloadFormat as DownloadFormat;
 use CRM_Certificate_BAO_CompuCertificateStatus as CompuCertificateStatus;
 use CRM_Certificate_BAO_CompuCertificateEntityType as CompuCertificateEntityType;
+use CRM_Certificate_BAO_CompuCertificateRelationshipType as CompuCertificateRelationshipType;
 
 class CRM_Certificate_BAO_CompuCertificate extends CRM_Certificate_DAO_CompuCertificate {
 
@@ -60,6 +62,47 @@ class CRM_Certificate_BAO_CompuCertificate extends CRM_Certificate_DAO_CompuCert
   }
 
   /**
+   * Returns all the certificate(s) configured for an entity based on the configured relationship types.
+   *
+   * @param int $entity
+   * @param int $contactId
+   *
+   * @return array
+   *   Returns an array of certificate configuration grouped by the related contact ids.
+   */
+  public static function getRelationshipEntityCertificates($entity, $contactId) {
+    $certificateRelationshipType = new CompuCertificateRelationshipType();
+    $certificateRelationshipType->joinAdd(['relationship_type_id', new Relationship(), 'relationship_type_id'], 'INNER', 'rlt');
+    $certificateRelationshipType->whereAdd("
+    (
+      (rlt.start_date IS NULL AND rlt.end_date IS NULL AND rlt.is_active = 1) OR
+      (rlt.start_date <= date(NOW()) AND rlt.end_date IS NULL) OR 
+      (rlt.start_date IS NULL AND rlt.end_date > date(NOW())) OR 
+      (rlt.start_date <= date(NOW()) AND rlt.end_date > date(NOW()))
+    )");
+    $certificateRelationshipType->whereAdd('rlt.is_active = 1');
+
+    $certificateBAO = new self();
+    $certificateBAO->joinAdd(['id', new CompuCertificateEntityType(), 'certificate_id'], 'LEFT', 'cert_type');
+    $certificateBAO->joinAdd(['id', new CompuCertificateStatus(), 'certificate_id'], 'LEFT', 'cert_status');
+    $certificateBAO->joinAdd(['id', $certificateRelationshipType, 'certificate_id'], 'INNER');
+    $certificateBAO->whereAdd('entity = ' . $entity);
+    $certificateBAO->whereAdd('contact_id_a = ' . $contactId);
+    $certificateBAO->whereDateIsValid();
+    $certificateBAO->selectAdd();
+    $certificateBAO->selectAdd(self::$_tableName . '.id as certificate_id, ' . self::$_tableName . '.start_date, ' . self::$_tableName . '.end_date, name, entity, entity_type_id, status_id, template_id, download_format, contact_id_b as related_contact, contact_id_a as contact');
+    $certificateBAO->find();
+
+    $configuredCertificates = $certificateBAO->fetchAll();
+    $groupedByRelatedContactId = [];
+    foreach ($configuredCertificates as $configuredCertificate) {
+      $groupedByRelatedContactId[$configuredCertificate['related_contact']][] = $configuredCertificate;
+    }
+
+    return $groupedByRelatedContactId;
+  }
+
+  /**
    * Returns the supported download formats.
    *
    * @return array
@@ -75,7 +118,8 @@ class CRM_Certificate_BAO_CompuCertificate extends CRM_Certificate_DAO_CompuCert
    * Add condition to ensure the certificate start_date and end_date is valid.
    */
   public function whereDateIsValid() {
-    $this->whereAdd('(start_date IS NULL OR date(start_date) <= date(NOW())) AND (end_date IS NULL OR date(end_date) >= date(NOW()) )');
+    $prefix = self::$_tableName;
+    $this->whereAdd("({$prefix}.start_date IS NULL OR date({$prefix}.start_date) <= date(NOW())) AND ({$prefix}.end_date IS NULL OR date({$prefix}.end_date) >= date(NOW()) )");
   }
 
 }

--- a/CRM/Certificate/Entity/AbstractEntity.php
+++ b/CRM/Certificate/Entity/AbstractEntity.php
@@ -1,9 +1,18 @@
 <?php
 
+use CRM_Certificate_BAO_CompuCertificate as CompuCertificate;
+
 /**
  * This is a shared interface for supported certificate entities.
  */
 abstract class CRM_Certificate_Entity_AbstractEntity {
+
+  /**
+   * Returns the current entity;
+   *
+   * @return int
+   */
+  abstract public function getEntity();
 
   /**
    * Stores a certificate configuration
@@ -111,6 +120,26 @@ abstract class CRM_Certificate_Entity_AbstractEntity {
   }
 
   /**
+   * Gets entity certificates available for a contact based on relationship.
+   *
+   * @param int $contactId
+   *  Id of the contact to retrieve related contact certificates for.
+   *
+   * @return Array
+   */
+  public function getRelationshipCertificates($contactId) {
+    $certificates = [];
+    $configuredCertificates = CompuCertificate::getRelationshipEntityCertificates($this->getEntity(), $contactId);
+
+    foreach ($configuredCertificates as $relatedContactId => $configuredCertificate) {
+      //for the related contacts, get their certificates that matches the certificate configuration.
+      $certificates = array_merge($this->formatConfiguredCertificatesForContact($configuredCertificate, $relatedContactId), $certificates);
+    }
+
+    return $certificates;
+  }
+
+  /**
    * Add entity specific retrieval conditions.
    *
    * @param \CRM_Certificate_BAO_CompuCertificate $certificateBAO
@@ -138,9 +167,20 @@ abstract class CRM_Certificate_Entity_AbstractEntity {
    * @param int $contactId
    *  Id of the contact to retrieve certificates for.
    *
-   * @return Array
+   * @return array
    */
   abstract public function getContactCertificates($contactId);
+
+  /**
+   * Formats certificate configurations into an entity certificate.
+   *
+   * @param array $configuredCertificates
+   *  The configured certificates to format.
+   * @param int $contactId
+   *  The contact ID.
+   * @return array
+   */
+  abstract public function formatConfiguredCertificatesForContact(array $configuredCertificates, $contactId);
 
   /**
    * Gets an entity certificate download URL.

--- a/CRM/Certificate/Entity/Case.php
+++ b/CRM/Certificate/Entity/Case.php
@@ -145,6 +145,7 @@ class CRM_Certificate_Entity_Case extends CRM_Certificate_Entity_AbstractEntity 
             'end_date' => $configuredCertificate['end_date'],
             'start_date' => $configuredCertificate['start_date'],
             'type' => 'Case',
+            'status' => $caseContact['case_id.status_id.label'],
             'linked_to' => $caseContact['case_id.case_type_id.title'],
             'download_link' => $this->getCertificateDownloadUrl($caseContact['case_id'], $contactId, TRUE),
           ];

--- a/CRM/Certificate/Entity/Case.php
+++ b/CRM/Certificate/Entity/Case.php
@@ -102,7 +102,7 @@ class CRM_Certificate_Entity_Case extends CRM_Certificate_Entity_AbstractEntity 
 
     $certificateBAO->joinAdd(['id', new CRM_Certificate_BAO_CompuCertificateEntityType(), 'certificate_id']);
     $certificateBAO->joinAdd(['id', new CRM_Certificate_BAO_CompuCertificateStatus(), 'certificate_id']);
-    $certificateBAO->whereAdd('entity = ' . CRM_Certificate_Enum_CertificateType::CASES);
+    $certificateBAO->whereAdd('entity = ' . $this->getEntity());
     $certificateBAO->whereAdd('entity_type_id = ' . $case['case_type_id']);
     $certificateBAO->whereAdd('status_id = ' . $case['status_id']);
   }
@@ -111,9 +111,16 @@ class CRM_Certificate_Entity_Case extends CRM_Certificate_Entity_AbstractEntity 
    * {@inheritDoc}
    */
   public function getContactCertificates($contactId) {
-    $certificates = [];
+    $configuredCertificates = CompuCertificate::getEntityCertificates($this->getEntity());
 
-    $configuredCertificates = CompuCertificate::getEntityCertificates(CertificateType::CASES);
+    return $this->formatConfiguredCertificatesForContact($configuredCertificates, $contactId);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function formatConfiguredCertificatesForContact(array $configuredCertificates, $contactId) {
+    $certificates = [];
 
     foreach ($configuredCertificates as $configuredCertificate) {
       $result = civicrm_api3('CaseContact', 'get', [
@@ -160,6 +167,10 @@ class CRM_Certificate_Entity_Case extends CRM_Certificate_Entity_AbstractEntity 
     $downloadUrl = htmlspecialchars_decode(CRM_Utils_System::url('civicrm/certificates/case', $query, $absolute));
 
     return $downloadUrl;
+  }
+
+  public function getEntity() {
+    return CertificateType::CASES;
   }
 
 }

--- a/CRM/Certificate/Entity/EntityFactory.php
+++ b/CRM/Certificate/Entity/EntityFactory.php
@@ -3,7 +3,7 @@
 class CRM_Certificate_Entity_EntityFactory {
 
   /**
-   * @return CRM_Certificate_Entity_EntityInterface
+   * @return CRM_Certificate_Entity_AbstractEntity
    */
   public static function create($entity) {
     switch ($entity) {

--- a/CRM/Certificate/Entity/Event.php
+++ b/CRM/Certificate/Entity/Event.php
@@ -121,7 +121,7 @@ class CRM_Certificate_Entity_Event extends CRM_Certificate_Entity_AbstractEntity
     $certificateBAO->joinAdd(['id', new CRM_Certificate_BAO_CompuCertificateEntityType(), 'certificate_id'], 'LEFT');
     $certificateBAO->joinAdd(['id', new CRM_Certificate_BAO_CompuCertificateStatus(), 'certificate_id'], 'LEFT');
     $certificateBAO->joinAdd(['id', new CRM_Certificate_BAO_CompuCertificateEventAttribute(), 'certificate_id'], 'LEFT');
-    $certificateBAO->whereAdd('entity = ' . CRM_Certificate_Enum_CertificateType::EVENTS);
+    $certificateBAO->whereAdd('entity = ' . $this->getEntity());
     $certificateBAO->whereAdd('entity_type_id = ' . $participant['event_id'] . ' OR entity_type_id IS NULL');
     $certificateBAO->whereAdd('status_id = ' . $participant['participant_status_id'] . ' OR status_id IS NULL');
     $certificateBAO->whereAdd('participant_type_id IN (' . $participantRoleIds . ') OR participant_type_id IS NULL');
@@ -131,9 +131,13 @@ class CRM_Certificate_Entity_Event extends CRM_Certificate_Entity_AbstractEntity
    * {@inheritDoc}
    */
   public function getContactCertificates($contactId) {
-    $certificates = [];
+    $configuredCertificates = CompuCertificate::getEntityCertificates($this->getEntity());
 
-    $configuredCertificates = CompuCertificate::getEntityCertificates(CertificateType::EVENTS);
+    return $this->formatConfiguredCertificatesForContact($configuredCertificates, $contactId);
+  }
+
+  public function formatConfiguredCertificatesForContact(array $configuredCertificates, $contactId) {
+    $certificates = [];
 
     foreach ($configuredCertificates as $configuredCertificate) {
       $eventAttribute = $this->getCertificateEventAttribute($configuredCertificate['certificate_id']);
@@ -194,6 +198,13 @@ class CRM_Certificate_Entity_Event extends CRM_Certificate_Entity_AbstractEntity
     $downloadUrl = htmlspecialchars_decode(CRM_Utils_System::url('civicrm/certificates/event', $query, $absolute));
 
     return $downloadUrl;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function getEntity() {
+    return CertificateType::EVENTS;
   }
 
 }

--- a/CRM/Certificate/Entity/Event.php
+++ b/CRM/Certificate/Entity/Event.php
@@ -176,6 +176,9 @@ class CRM_Certificate_Entity_Event extends CRM_Certificate_Entity_AbstractEntity
           'name' => $configuredCertificate['name'],
           'type' => 'Event',
           'linked_to' => $participant['event_title'],
+          'status' => $participant['participant_status'],
+          'end_date' => $configuredCertificate['end_date'],
+          'start_date' => $configuredCertificate['start_date'],
           'download_link' => $this->getCertificateDownloadUrl($participant['id'], $contactId, TRUE),
           'participant_role' => $participant['participant_role'],
         ];

--- a/CRM/Certificate/Entity/Membership.php
+++ b/CRM/Certificate/Entity/Membership.php
@@ -103,7 +103,7 @@ class CRM_Certificate_Entity_Membership extends CRM_Certificate_Entity_AbstractE
 
     $certificateBAO->joinAdd(['id', new CRM_Certificate_BAO_CompuCertificateEntityType(), 'certificate_id'], "LEFT");
     $certificateBAO->joinAdd(['id', new CRM_Certificate_BAO_CompuCertificateStatus(), 'certificate_id'], "LEFT");
-    $certificateBAO->whereAdd('entity = ' . CRM_Certificate_Enum_CertificateType::MEMBERSHIPS);
+    $certificateBAO->whereAdd('entity = ' . $this->getEntity());
     $certificateBAO->whereAdd("entity_type_id = {$membership['membership_type_id']} OR entity_type_id IS NULL");
     $certificateBAO->whereAdd("status_id = {$membership['status_id']}  OR status_id IS NULL");
   }
@@ -112,9 +112,15 @@ class CRM_Certificate_Entity_Membership extends CRM_Certificate_Entity_AbstractE
    * {@inheritDoc}
    */
   public function getContactCertificates($contactId) {
-    $certificates = [];
+    $configuredCertificates = CompuCertificate::getEntityCertificates($this->getEntity());
+    return $this->formatConfiguredCertificatesForContact($configuredCertificates, $contactId);
+  }
 
-    $configuredCertificates = CompuCertificate::getEntityCertificates(CertificateType::MEMBERSHIPS);
+  /**
+   * {@inheritDoc}
+   */
+  public function formatConfiguredCertificatesForContact(array $configuredCertificates, $contactId) {
+    $certificates = [];
 
     foreach ($configuredCertificates as $configuredCertificate) {
       $condition = [
@@ -164,6 +170,10 @@ class CRM_Certificate_Entity_Membership extends CRM_Certificate_Entity_AbstractE
     $downloadUrl = htmlspecialchars_decode(CRM_Utils_System::url('civicrm/certificates/membership', $query, $absolute));
 
     return $downloadUrl;
+  }
+
+  public function getEntity() {
+    return CertificateType::MEMBERSHIPS;
   }
 
 }

--- a/CRM/Certificate/Entity/Membership.php
+++ b/CRM/Certificate/Entity/Membership.php
@@ -148,6 +148,9 @@ class CRM_Certificate_Entity_Membership extends CRM_Certificate_Entity_AbstractE
           'membership_id' => $membership['id'],
           'name' => $configuredCertificate['name'],
           'type' => 'Membership',
+          'status' => CRM_Member_BAO_MembershipStatus::getMembershipStatus($membership['status_id'])["name"] ?? "",
+          'end_date' => $configuredCertificate['end_date'],
+          'start_date' => $configuredCertificate['start_date'],
           'linked_to' => $membership['membership_name'],
           'download_link' => $this->getCertificateDownloadUrl($membership['id'], $contactId, TRUE),
         ];

--- a/CRM/Certificate/Test/Fabricator/Relationship.php
+++ b/CRM/Certificate/Test/Fabricator/Relationship.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * Fabricates relationship using API calls.
+ */
+class CRM_Certificate_Test_Fabricator_Relationship {
+
+  private static $defaultParams = [
+    'is_active' => 1,
+    'start_date' => NULL,
+    'end_date' => NULL,
+  ];
+
+  public static function fabricate($params = []) {
+    $params = array_merge(self::$defaultParams, $params);
+
+    $result = civicrm_api3('Relationship', 'create', $params);
+
+    return array_shift($result['values']);
+  }
+
+}

--- a/CRM/Certificate/Test/Fabricator/RelationshipType.php
+++ b/CRM/Certificate/Test/Fabricator/RelationshipType.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * Fabricates relationship type using API calls.
+ */
+class CRM_Certificate_Test_Fabricator_RelationshipType {
+
+  private static $defaultParams = [
+    'sequential' => 1,
+    'name_a_b' => 'test AB',
+    'name_b_a' => 'test BA',
+    'contact_type_a' => 'Individual',
+    'contact_type_b' => 'Individual',
+  ];
+
+  public static function fabricate($params = []) {
+    $params = array_merge(self::$defaultParams, $params);
+    $result = civicrm_api3(
+      'RelationshipType',
+      'create',
+      $params
+    );
+
+    return array_shift($result['values']);
+  }
+
+}

--- a/CRM/Certificate/Test/Helper/Case.php
+++ b/CRM/Certificate/Test/Helper/Case.php
@@ -48,6 +48,7 @@ trait CRM_Certificate_Test_Helper_Case {
       'linked_to' => [$caseType['id']],
       'statuses' => [$caseStatus['value']],
       'start_date' => $params['start_date'] ?? date('Y-m-d'),
+      'relationship_types' => $params['relationship_types'] ?? [],
       'end_date' => $params['end_date'] ?? date('Y-m-d', strtotime(date('Y-m-d') . " 10 days")),
     ];
 

--- a/CRM/Certificate/Test/Helper/Event.php
+++ b/CRM/Certificate/Test/Helper/Event.php
@@ -39,6 +39,7 @@ trait CRM_Certificate_Test_Helper_Event {
       'statuses' => $statuses,
       'participant_type_id' => 1,
       'start_date' => date('Y-m-d'),
+      'relationship_types' => $params['relationship_types'] ?? [],
       'end_date' => date('Y-m-d', strtotime(date('Y-m-d') . " 10 days")),
     ], $params);
 

--- a/CRM/Certificate/Test/Helper/Membership.php
+++ b/CRM/Certificate/Test/Helper/Membership.php
@@ -36,6 +36,7 @@ trait CRM_Certificate_Test_Helper_Membership {
       'linked_to' => $membershipType['id'],
       'statuses' => $membershipStatus['id'],
       'start_date' => date('Y-m-d'),
+      'relationship_types' => $params['relationship_types'] ?? [],
       'end_date' => date('Y-m-d', strtotime(date('Y-m-d') . " 10 days")),
     ], $params);
 

--- a/api/v3/CompuCertificate/Getrelationshipcertificates.php
+++ b/api/v3/CompuCertificate/Getrelationshipcertificates.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * CompuCertificate.Getrelationshipcertificates API specification (optional)
+ * This is used for documentation and validation.
+ *
+ * @param array $spec description of fields supported by this API call
+ *
+ * @see https://docs.civicrm.org/dev/en/latest/framework/api-architecture/
+ */
+function _civicrm_api3_compu_certificate_Getrelationshipcertificates_spec(&$spec) {
+  $spec['entity'] = [
+    'title' => 'Entity',
+    'description' => 'Retrieve certificates for specific entity',
+    'type' => CRM_Utils_Type::T_STRING,
+  ];
+  $spec['contact_id'] = [
+    'title' => 'Contact ID',
+    'description' => 'Id of the contact to retrieve certificates for',
+    'type' => CRM_Utils_Type::T_INT,
+  ];
+}
+
+/**
+ * CompuCertificate.Getrelationshipcertificates API
+ *
+ * @param array $params
+ *
+ * @return array
+ *   API result descriptor
+ *
+ * @see civicrm_api3_create_success
+ *
+ * @throws API_Exception
+ */
+function civicrm_api3_compu_certificate_Getrelationshipcertificates($params) {
+  $certificateWrapper = new CRM_Certificate_Api_Wrapper_CompuCertificate();
+  $certificateList = $certificateWrapper->getRelationshipCertificates($params);
+  return civicrm_api3_create_success($certificateList, $params, 'CompuCertificate', 'Getrelationshipcertificates');
+}

--- a/tests/phpunit/api/v3/CompuCertificate/GetrelationshipcertificatesTest.php
+++ b/tests/phpunit/api/v3/CompuCertificate/GetrelationshipcertificatesTest.php
@@ -1,0 +1,142 @@
+<?php
+
+use CRM_Certificate_Test_Fabricator_Contact as ContactFabricator;
+use CRM_Certificate_Test_Fabricator_Relationship as RelationshipFabricator;
+use CRM_Certificate_Test_Fabricator_RelationshipType as RelationshipTypeFabricator;
+
+/**
+ * CompuCert.Getrelatedcontactcertificates API Test Case
+ *
+ * @group headless
+ */
+class api_v3_CompuCertificate_GetrelatedcontactcertificatesTest extends BaseHeadlessTest {
+
+  use \Civi\Test\Api3TestTrait;
+  use CRM_Certificate_Test_Helper_Case;
+  use CRM_Certificate_Test_Helper_Event;
+  use CRM_Certificate_Test_Helper_Session;
+  use CRM_Certificate_Test_Helper_Membership;
+  use CRM_Certificate_Test_Helper_Certificate;
+
+  /**
+   * Holds logged in contact/case client id.
+   *
+   * @var int
+   */
+  private $client_id;
+
+  public function setUp() {
+    parent::setUp();
+    $contact = ContactFabricator::fabricate();
+    $this->registerCurrentLoggedInContactInSession($contact['id']);
+    $this->client_id = $contact['id'];
+  }
+
+  /**
+   * Test that the api returns available cases certificate
+   * available to a contact via relationship to anotehr contact.
+   */
+  public function testRelatedCaseCertficateIsReturnedForContact() {
+    $relationshipTypeParams = [
+      'name_a_b' => 'A Employee of',
+      'name_b_a' => 'A Empoyer of',
+    ];
+
+    $relationshipType = RelationshipTypeFabricator::fabricate($relationshipTypeParams);
+    $contactA = ContactFabricator::fabricate();
+    $contactB = ContactFabricator::fabricate();
+
+    // Contact B is Employer of Contact A
+    $params = [
+      'contact_id_a' => $contactA['id'],
+      'contact_id_b' => $contactB['id'],
+      'relationship_type_id' => $relationshipType['id'],
+    ];
+    RelationshipFabricator::fabricate($params);
+
+    // Contact B has a valid certificate, with access given to Employee relationship
+    $caseParam = ['client_id' => $contactB['id'], 'relationship_types' => [$relationshipType['id']]];
+    $case = $this->createCaseCertificate($caseParam);
+
+    // Contact A should have access to Contact B certificates based on their relationship.
+    $param = ['entity' => 'case', 'contact_id' => $contactA['id']];
+    $results = $this->callApiSuccess('CompuCertificate', 'getrelationshipcertificates', $param);
+
+    $this->assertEquals(1, $results['count']);
+    $this->assertEquals($case['id'], $results['values'][0]['case_id']);
+  }
+
+  public function testRelatedEventCertficateIsReturnedForContact() {
+    $relationshipTypeParams = [
+      'name_a_b' => 'A Employee of',
+      'name_b_a' => 'A Empoyer of',
+    ];
+
+    $relationshipType = RelationshipTypeFabricator::fabricate($relationshipTypeParams);
+    $contactA = ContactFabricator::fabricate();
+    $contactB = ContactFabricator::fabricate();
+
+    // Contact B is Employer of Contact A
+    $params = [
+      'contact_id_a' => $contactA['id'],
+      'contact_id_b' => $contactB['id'],
+      'relationship_type_id' => $relationshipType['id'],
+    ];
+    RelationshipFabricator::fabricate($params);
+
+    // Contact B has a valid certificate, with access given to Employee relationship
+    $participant = $this->createParticipant(['contact_id' => $contactB['id']]);
+    $certificateParam = ['linked_to' => [$participant['event_id']], 'relationship_types' => [$relationshipType['id']], 'statuses' => [$participant['participant_status_id']]];
+    $this->createEventCertificate($certificateParam);
+
+    // Contact A should have access to Contact B certificates based on their relationship.
+    $param = ['entity' => 'event', 'contact_id' => $contactA['id']];
+    $results = $this->callApiSuccess('CompuCertificate', 'getrelationshipcertificates', $param);
+
+    $this->assertEquals(1, $results['count']);
+    $this->assertEquals($participant['id'], $results['values'][0]['participant_id']);
+  }
+
+  public function testRelatedMembershipCertficateIsReturnedForContact() {
+    $relationshipTypeParams = [
+      'name_a_b' => 'A Employee of',
+      'name_b_a' => 'A Empoyer of',
+    ];
+
+    $relationshipType = RelationshipTypeFabricator::fabricate($relationshipTypeParams);
+    $contactA = ContactFabricator::fabricate();
+    $contactB = ContactFabricator::fabricate();
+
+    // Contact B is Employer of Contact A
+    $params = [
+      'contact_id_a' => $contactA['id'],
+      'contact_id_b' => $contactB['id'],
+      'relationship_type_id' => $relationshipType['id'],
+    ];
+    RelationshipFabricator::fabricate($params);
+
+    // Contact B has a valid certificate, with access given to Employee relationship
+    $membership = $this->createMembership(['contact_id' => $contactB['id']]);
+    $this->createMembershipCertificate(
+      [
+        'statuses'  => [$membership['status_id']],
+        'relationship_types' => [$relationshipType['id']],
+        'linked_to' => [$membership['membership_type_id']],
+      ]
+    );
+
+    // Contact A should have access to Contact B certificates based on their relationship.
+    $param = ['entity' => 'membership', 'contact_id' => $contactA['id']];
+
+    $results = $this->callApiSuccess('CompuCertificate', 'getrelationshipcertificates', $param);
+
+    $this->assertEquals(1, $results['count']);
+    $this->assertEquals($membership['id'], $results['values'][0]['membership_id']);
+  }
+
+  public function tearDown() {
+    $this->unregisterCurrentLoggedInContactFromSession();
+    parent::tearDown();
+  }
+
+}


### PR DESCRIPTION
## Overview
This PR adds a new endpoint `CompuCertificate.Getrelationshipcertificates` that will be used by contacts to retrieve certificates they have access to based on a defined relationship.

## Before
API doesn't exist.

## After
API Exists
![image](https://user-images.githubusercontent.com/85277674/215037161-ee51e602-9c21-477e-aacb-6cb306561779.png)


## Technical Details
The major change introduced by this PR is the method used in retrieving entity certificates based on configured  relationship types https://github.com/compucorp/uk.co.compucorp.certificate/blob/87217ac90748317f993018f6a6fb613e603992ce/CRM/Certificate/BAO/CompuCertificate.php#L74-L104

This code will translate to the SQL below:

```
SELECT compucertificate_certificate.id AS certificate_id,
       compucertificate_certificate.start_date,
       compucertificate_certificate.end_date,
       name,
       entity,
       entity_type_id,
       status_id,
       template_id,
       download_format,
       contact_id_b AS related_contact,
       contact_id_a AS contact
FROM `compucertificate_certificate`
LEFT JOIN `compucertificate_certificate_entity_type` AS `cert_type` ON (`cert_type`.`certificate_id`=`compucertificate_certificate`.`id`)
LEFT JOIN `compucertificate_certificate_status` AS `cert_status` ON (`cert_status`.`certificate_id`=`compucertificate_certificate`.`id`)
INNER JOIN `compucertificate_relationship_type` ON (`compucertificate_relationship_type`.`certificate_id`=`compucertificate_certificate`.`id`)
INNER JOIN `civicrm_relationship` AS `rlt` ON (`rlt`.`relationship_type_id`=`compucertificate_relationship_type`.`relationship_type_id`)
WHERE ((((rlt.start_date IS NULL
          AND rlt.end_date IS NULL
          AND rlt.is_active = 1)
         OR (rlt.start_date <= date(NOW())
             AND rlt.end_date IS NULL)
         OR (rlt.start_date IS NULL
             AND rlt.end_date > date(NOW()))
         OR (rlt.start_dat <= date(NOW())
             AND rlt.end_date > date(NOW()))))
       AND (rlt.is_active = 1))
  AND (entity = 1)
  AND (contact_id_a = 1)
  AND ((compucertificate_certificate.start_date IS NULL
        OR date(compucertificate_certificate.start_date) <= date(NOW()))
       AND (compucertificate_certificate.end_date IS NULL
            OR date(compucertificate_certificate.end_date) >= date(NOW())))
```

To retrieve the certificates a contact has access to based on their relationship with another contact:
- Retrieve all certificate configurations that have relationship_types.
- Get contact active relationships of these relationship types.
- Ensure a certificate configuration is returned if relationship_types have been defined and the contact has an active relationship with the defined relationship_types using INNER JOIN.

