### PR TITLE
FOSFAB-47: Support HTML download and grant access via relationship

### DIFF
--- a/CRM/Certificate/BAO/CompuCertificate.php
+++ b/CRM/Certificate/BAO/CompuCertificate.php
@@ -122,4 +122,16 @@ class CRM_Certificate_BAO_CompuCertificate extends CRM_Certificate_DAO_CompuCert
     $this->whereAdd("({$prefix}.start_date IS NULL OR date({$prefix}.start_date) <= date(NOW())) AND ({$prefix}.end_date IS NULL OR date({$prefix}.end_date) >= date(NOW()) )");
   }
 
+  /**
+   * Get the instance relationship types
+   */
+  public function getRelationshipTypes(string $column = NULL) {
+    $relationshipTypes = CompuCertificateRelationshipType::getByCertificateId($this->id);
+    if (!empty($relationshipTypes) && !empty($relationshipTypes)) {
+      $relationshipTypes = array_column($relationshipTypes, $column);
+    }
+
+    return $relationshipTypes;
+  }
+
 }

--- a/CRM/Certificate/Enum/DownloadFormat.php
+++ b/CRM/Certificate/Enum/DownloadFormat.php
@@ -8,5 +8,6 @@ class CRM_Certificate_Enum_DownloadFormat {
 
   const PDF = '1';
   const IMAGE = '2';
+  const HTML = '3';
 
 }

--- a/CRM/Certificate/Service/CertificateAccessChecker.php
+++ b/CRM/Certificate/Service/CertificateAccessChecker.php
@@ -64,7 +64,7 @@ class CRM_Certificate_Service_CertificateAccessChecker {
    */
   private function hasViewPermissionByRelationship() {
     $allowedRelationshipTypeIds = $this->certificate->getRelationshipTypes('relationship_type_id');
-    if (!empty($allowedRelationshipTypeIds)) {
+    if (!empty($allowedRelationshipTypeIds) && !empty(CRM_Core_Session::getLoggedInContactID())) {
       $relationships = Relationship::get()
         ->addWhere('contact_id_a', '=', CRM_Core_Session::getLoggedInContactID())
         ->addWhere('contact_id_b', '=', $this->contactId)

--- a/CRM/Certificate/Service/CertificateAccessChecker.php
+++ b/CRM/Certificate/Service/CertificateAccessChecker.php
@@ -1,0 +1,83 @@
+<?php
+
+use Civi\Api4\Relationship;
+
+class CRM_Certificate_Service_CertificateAccessChecker {
+
+  public int $contactId;
+
+  public \CRM_Certificate_BAO_CompuCertificate $certificate;
+
+  /**
+   * Constructs a new instance of the class.
+   *
+   * @param int $contactId
+   * @param \CRM_Certificate_BAO_CompuCertificate $certificate
+   */
+  public function __construct($contactId, $certificate) {
+    $this->contactId = $contactId;
+    $this->certificate = $certificate;
+  }
+
+  /**
+   * @return bool
+   */
+  public function check() {
+    return $this->hasViewPermission() || $this->hasViewPermissionByRelationship();
+  }
+
+  /**
+   * Performs access level check to ensure user has access to contact certificate
+   *
+   * The user would be granted access to the certificate if any of the condition below is true
+   * - if the contact id is the same as the current logged in user
+   * - if a checksum is provided in the URL and it is valid for the contact id
+   * - Lastly, the user is not logged in and no checksum is provided if the user has
+   *   the express permission to view the contact
+   *
+   * - if all fails return false.
+   *
+   * @return int - contact id
+   */
+  private function hasViewPermission() {
+    $userChecksum = CRM_Utils_Request::retrieve('cs', 'String');
+
+    $isLoggedInUser = CRM_Core_Session::getLoggedInContactID() == $this->contactId;
+    $hasViewPermission = CRM_Contact_BAO_Contact_Permission::allow($this->contactId, CRM_Core_Permission::VIEW);
+    $checksumValid = FALSE;
+
+    if ($userChecksum && $this->contactId) {
+      $checksumValid = CRM_Contact_BAO_Contact_Utils::validChecksum($this->contactId, $userChecksum);
+    }
+
+    if ($checksumValid || $isLoggedInUser || $hasViewPermission) {
+      return $this->contactId;
+    }
+
+    return FALSE;
+  }
+
+  /**
+   * Checks user has an active relationship with the certificate owner.
+   *
+   * The 'relationship' is of the relationship_type defined on the certificate configuration.
+   */
+  private function hasViewPermissionByRelationship() {
+    $allowedRelationshipTypeIds = $this->certificate->getRelationshipTypes('relationship_type_id');
+    if (!empty($allowedRelationshipTypeIds)) {
+      $relationships = Relationship::get()
+        ->addWhere('contact_id_a', '=', CRM_Core_Session::getLoggedInContactID())
+        ->addWhere('contact_id_b', '=', $this->contactId)
+        ->addWhere('relationship_type_id', 'IN', $allowedRelationshipTypeIds)
+        ->setCurrent(TRUE)
+        ->setCheckPermissions(FALSE)
+        ->execute();
+
+      if (count($relationships)) {
+        return TRUE;
+      }
+    }
+    return FALSE;
+  }
+
+}


### PR DESCRIPTION
## Overview
In this PR we grant a user download access to another user's certificate if they have the expected relationship with the user, we also allow a user to download a certificate HTML.

## Technical Details
The user can download a certificate HTML by specifying `format=html` in the certificate download URL