### PR TITLE
FOSFAB-44: Limit relationship types to organization relationship

### DIFF
--- a/CRM/Certificate/Form/CertificateConfigure.php
+++ b/CRM/Certificate/Form/CertificateConfigure.php
@@ -123,12 +123,18 @@ class CRM_Certificate_Form_CertificateConfigure extends CRM_Core_Form {
       ['class' => 'form-control']
     );
 
-    $this->addEntityRef('relationship_types', ts('Access For Related Contacts'), [
-      'entity' => 'RelationshipType',
-      'placeholder' => ts('- Select Relationship -'),
-      'select' => ['multiple' => TRUE],
-      'class' => 'form-control',
-    ], FALSE);
+    $this->add(
+      'select2',
+      'relationship_types',
+      ts('Access For Related Contacts'),
+      $this->getRelationshipTypes(),
+      FALSE,
+      [
+        'class' => 'huge',
+        'placeholder' => ts('- select -'),
+        'multiple' => TRUE,
+      ]
+    );
 
     $this->addButtons([
       [
@@ -334,6 +340,22 @@ class CRM_Certificate_Form_CertificateConfigure extends CRM_Core_Form {
     if (strtotime($values['end_date']) <= strtotime($values['start_date'])) {
       $errors['end_date'] = ts('End date field must be after start date');
     }
+  }
+
+  /**
+   * Returns organisation relationship types.
+   *
+   * @return array
+   */
+  public function getRelationshipTypes() {
+    $relationshipTypes = [];
+    foreach (CRM_Core_PseudoConstant::relationshipType() as $value) {
+      if ($value['contact_type_b'] == 'Organization') {
+        $relationshipTypes[] = ['id' => $value['id'], 'text' => $value['label_a_b']];
+      }
+    }
+
+    return $relationshipTypes;
   }
 
 }


### PR DESCRIPTION
## Overview
In this PR we limit the relationship types to organization relationship types, and also change the select input to a simple select to improve the user experience.

## Before
<img width="806" alt="Screenshot 2023-01-30 at 14 43 32" src="https://user-images.githubusercontent.com/85277674/215493860-b7fc26f3-0389-4168-9e00-d0f9015c0b8b.png">


## After
<img width="807" alt="Screenshot 2023-01-30 at 14 42 38" src="https://user-images.githubusercontent.com/85277674/215493661-ed8f3c28-8072-4e03-b2b9-4408285f535f.png">