### PR TITLE
FOSFAB-72: Use default image format

### DIFF
--- a/CRM/Certificate/BAO/CompuCertificateImageFormat.php
+++ b/CRM/Certificate/BAO/CompuCertificateImageFormat.php
@@ -252,10 +252,26 @@ class CRM_Certificate_BAO_CompuCertificateImageFormat extends CRM_Core_DAO_Optio
    *   Field value to search for.
    *
    * @return array
-   *   associative array of name/value pairs
+   *   Associative array of name/value pairs
    */
   public static function getImageFormat($field, $val) {
     $params = ['is_active' => 1, $field => $val];
+    $imageFormat = [];
+    if (self::retrieve($params, $imageFormat)) {
+      return $imageFormat;
+    }
+
+    return NULL;
+  }
+
+  /**
+   * Get the default Image Format values.
+   *
+   * @return array
+   *   Associative array containing the default Image Format values.
+   */
+  public static function getDefaultFormat() {
+    $params = ['is_active' => 1, 'is_default' => 1];
     $imageFormat = [];
     if (self::retrieve($params, $imageFormat)) {
       return $imageFormat;

--- a/CRM/Certificate/Service/CertificateDownloader.php
+++ b/CRM/Certificate/Service/CertificateDownloader.php
@@ -76,9 +76,17 @@ class CRM_Certificate_Service_CertificateDownloader {
    * @param int $imageFormatId
    */
   private function renderImage($html, $imageFormatId) {
+    $imageFormat = [];
+    if (is_null($imageFormatId)) {
+      $imageFormat = CompuCertificateImageFormatBAO::getDefaultFormat();
+    }
+    else {
+      $imageFormat = CompuCertificateImageFormatBAO::getImageFormat('id', $imageFormatId);
+    }
+
     $page = new CRM_Certificate_Page_CertificateDownload();
     $page->assign('certificateContent', $html);
-    $page->assign('imageFormat', json_encode(CompuCertificateImageFormatBAO::getImageFormat('id', $imageFormatId)));
+    $page->assign('imageFormat', json_encode($imageFormat));
     $page->run();
   }
 

--- a/templates/CRM/Certificate/Page/CertificateDownload.tpl
+++ b/templates/CRM/Certificate/Page/CertificateDownload.tpl
@@ -22,7 +22,7 @@
       extraCanvas.setAttribute('height',height);
       const ctx = extraCanvas.getContext('2d');
       ctx.drawImage(canvas,0,0,canvas.width, canvas.height,0,0,width,height);
-      const dataURL = extraCanvas.toDataURL(imageTypes[`${format}`] || imageTypes['jpg'], quality / 10);
+      const dataURL = extraCanvas.toDataURL(imageTypes[`${format.extension}`] || imageTypes['jpg'], quality / 10);
 
       const img = new Image();
       img.src = dataURL


### PR DESCRIPTION
## Overview
In this PR we allow the use of the default image format.

## Before
The default image format was not used if no format was assigned to the message template.

## After
The default image format is used if no format was assigned to the message template.
![asajj](https://user-images.githubusercontent.com/85277674/218715227-8af2813e-b438-487c-8ba2-e8c1a98b522f.gif)
