### PR TITLE
FOSFAB-37: Handle empty format properly

### DIFF
--- a/CRM/Certificate/Service/CertificateDownloader.php
+++ b/CRM/Certificate/Service/CertificateDownloader.php
@@ -86,7 +86,7 @@ class CRM_Certificate_Service_CertificateDownloader {
 
     $page = new CRM_Certificate_Page_CertificateDownload();
     $page->assign('certificateContent', $html);
-    $page->assign('imageFormat', json_encode($imageFormat));
+    $page->assign('imageFormat', json_encode($imageFormat ?? []));
     $page->run();
   }
 

--- a/CRM/Certificate/Service/CertificateDownloader.php
+++ b/CRM/Certificate/Service/CertificateDownloader.php
@@ -77,11 +77,12 @@ class CRM_Certificate_Service_CertificateDownloader {
    */
   private function renderImage($html, $imageFormatId) {
     $imageFormat = [];
-    if (is_null($imageFormatId)) {
-      $imageFormat = CompuCertificateImageFormatBAO::getDefaultFormat();
-    }
-    else {
+    if (!is_null($imageFormatId)) {
       $imageFormat = CompuCertificateImageFormatBAO::getImageFormat('id', $imageFormatId);
+    }
+
+    if (empty($imageFormat)) {
+      $imageFormat = CompuCertificateImageFormatBAO::getDefaultFormat();
     }
 
     $page = new CRM_Certificate_Page_CertificateDownload();

--- a/templates/CRM/Certificate/Page/CertificateDownload.tpl
+++ b/templates/CRM/Certificate/Page/CertificateDownload.tpl
@@ -9,6 +9,7 @@
 
   { literal }
   CRM.$(function ($) {
+   format = format || {}
    const container = document.getElementById("compu-certificate-content");
    let extension = format.extension || 'jpg';
    let quality = Math.max(format.quality || 10, 10);
@@ -22,7 +23,7 @@
       extraCanvas.setAttribute('height',height);
       const ctx = extraCanvas.getContext('2d');
       ctx.drawImage(canvas,0,0,canvas.width, canvas.height,0,0,width,height);
-      const dataURL = extraCanvas.toDataURL(imageTypes[`${format.extension}`] || imageTypes['jpg'], quality / 10);
+      const dataURL = extraCanvas.toDataURL(imageTypes[`${extension}`], quality / 10);
 
       const img = new Image();
       img.src = dataURL

--- a/templates/CRM/Certificate/Page/CertificateImageFormats.tpl
+++ b/templates/CRM/Certificate/Page/CertificateImageFormats.tpl
@@ -35,7 +35,6 @@
     <div class="spacer"></div>
     <div class="action-link">
       {crmButton q="action=add&reset=1" id="newImageFormat"  icon="plus-circle"}{ts}Add Image Format{/ts}{/crmButton}
-      {crmButton p="civicrm/admin" q="reset=1" class="cancel" icon="times"}{ts}Done{/ts}{/crmButton}
     </div>
 {/if}
 </div>


### PR DESCRIPTION
## Overview
In this PR we handle situations where an image format is empty or not appropriately retrieved, so it doesn't break the download functionality, but instead, the system is able to default to the 'JPG' format.