### PR TITLE
FOSFAB-102: Add token to get contact employer address 

### DIFF
--- a/CRM/Certificate/Service/CertificateDownloader.php
+++ b/CRM/Certificate/Service/CertificateDownloader.php
@@ -6,7 +6,7 @@ use CRM_Certificate_BAO_CompuCertificateTemplateImageFormat as CompuCertificateT
 
 class CRM_Certificate_Service_CertificateDownloader {
 
-  public int $format;
+  public ?int $format;
   public int $entityId;
   public int $contactId;
   public \CRM_Certificate_BAO_CompuCertificate $certificate;

--- a/CRM/Certificate/Test/Fabricator/Contact.php
+++ b/CRM/Certificate/Test/Fabricator/Contact.php
@@ -1,5 +1,7 @@
 <?php
 
+use Civi\Api4\Address;
+
 /**
  * Fabricates contacts using API calls.
  */
@@ -21,6 +23,41 @@ class CRM_Certificate_Test_Fabricator_Contact {
       $params
     );
     return array_shift($result['values']);
+  }
+
+  public static function fabricateWithAddress($params = []) {
+    $params = array_merge(self::$defaultParams, $params);
+    $params['display_name'] = "{$params['first_name']} {$params['last_name']}";
+    $result = civicrm_api3(
+      'Contact',
+      'create',
+      $params
+    );
+    $contact = array_shift($result['values']);
+
+    $contact['address'] = Address::save(FALSE)
+      ->addRecord([
+        "contact_id" => $contact['id'],
+        "location_type_id" => 5,
+        "is_primary" => TRUE,
+        "is_billing" => TRUE,
+        "street_address" => "Coldharbour Ln",
+        "street_number" => "42",
+        "supplemental_address_1" => "Supplementary Address 1",
+        "supplemental_address_2" => "Supplementary Address 2",
+        "supplemental_address_3" => "Supplementary Address 3",
+        "city" => "Hayes",
+        "postal_code" => "UB3 3EA",
+        "country_id" => 1226,
+        "manual_geo_code" => FALSE,
+        "timezone" => NULL,
+        "name" => NULL,
+        "master_id" => NULL,
+      ])
+      ->execute()
+      ->first();
+
+    return $contact;
   }
 
 }

--- a/CRM/Certificate/Token/Contact.php
+++ b/CRM/Certificate/Token/Contact.php
@@ -50,7 +50,7 @@ class CRM_Certificate_Token_Contact extends CRM_Certificate_Token_AbstractCertif
           ->addSelect('employer_id')
           ->addWhere('id', '=', $contactId)
           ->addChain('employerAddress', \Civi\Api4\Address::get()
-            ->addSelect('supplemental_address_1', 'supplemental_address_2', 'county_id:label', 'country_id:label', 'city')
+            ->addSelect('street_address', 'supplemental_address_1', 'county_id:label', 'country_id:label', 'city')
             ->addWhere('contact_id', '=', '$employer_id')
             ->addWhere('is_primary', '=', TRUE)
           )
@@ -80,8 +80,8 @@ class CRM_Certificate_Token_Contact extends CRM_Certificate_Token_AbstractCertif
   private function resolveFields($contact, &$resolvedTokens) {
     if (!empty($contact["employerAddress"])) {
       $address = [
+        $contact["employerAddress"][0]["street_address"],
         $contact["employerAddress"][0]["supplemental_address_1"],
-        $contact["employerAddress"][0]["supplemental_address_2"],
         $contact["employerAddress"][0]["city"],
         $contact["employerAddress"][0]["county_id:label"],
         $contact["employerAddress"][0]["country_id:label"],

--- a/CRM/Certificate/Token/Contact.php
+++ b/CRM/Certificate/Token/Contact.php
@@ -1,0 +1,94 @@
+<?php
+
+use Civi\Token\Event\TokenValueEvent;
+
+/**
+ * Class CRM_Certificate_Token_Contact
+ *
+ * Generate "certificate_contact.*" tokens.
+ *
+ * This class defines custom contact tokens
+ */
+class CRM_Certificate_Token_Contact extends CRM_Certificate_Token_AbstractCertificateToken {
+
+  const TOKEN = 'certificate contact';
+
+  /**
+   * Here we define list of the extra tokens we are adding
+   */
+  const customFields = [
+    "employer_inline_address" => "Employer Inline Address",
+  ];
+
+  public function __construct($tokenNames = []) {
+    $this->tokenNames = $tokenNames;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public static function entityTokens() {
+    return self::customFields;
+  }
+
+  /**
+   * To perform a bulk lookup before rendering tokens
+   *
+   * @param \Civi\Token\Event\TokenValueEvent $e
+   *
+   * @return mixed
+   */
+  public function prefetch(TokenValueEvent $e) {
+    $contactId = $e->getTokenProcessor()->getContextValues('contactId');
+
+    $resolvedTokens = [];
+
+    try {
+      if (is_array($contactId)) {
+        $contactId = $contactId[0];
+        $contact = \Civi\Api4\Contact::get()
+          ->addSelect('employer_id')
+          ->addWhere('id', '=', $contactId)
+          ->addChain('employerAddress', \Civi\Api4\Address::get()
+            ->addSelect('supplemental_address_1', 'supplemental_address_2', 'county_id:label', 'country_id:label', 'city')
+            ->addWhere('contact_id', '=', '$employer_id')
+            ->addWhere('is_primary', '=', TRUE)
+          )
+          ->execute()
+          ->first();
+
+        if (empty($contact)) {
+          return $resolvedTokens;
+        }
+
+        $this->resolveFields($contact, $resolvedTokens);
+      }
+    }
+    catch (Exception $e) {
+      CRM_Core_Session::setStatus('Error resolving tokens');
+    }
+
+    return $resolvedTokens;
+  }
+
+  /**
+   * Resolve the value of the custom contact token fields.
+   *
+   * @param array $contact
+   * @param array &$resolvedTokens
+   */
+  private function resolveFields($contact, &$resolvedTokens) {
+    if (!empty($contact["employerAddress"])) {
+      $address = [
+        $contact["employerAddress"][0]["supplemental_address_1"],
+        $contact["employerAddress"][0]["supplemental_address_2"],
+        $contact["employerAddress"][0]["city"],
+        $contact["employerAddress"][0]["county_id:label"],
+        $contact["employerAddress"][0]["country_id:label"],
+      ];
+
+      $resolvedTokens['employer_inline_address'] = implode(", ", array_filter($address));
+    }
+  }
+
+}

--- a/CRM/Certificate/Token/Contact.php
+++ b/CRM/Certificate/Token/Contact.php
@@ -50,7 +50,9 @@ class CRM_Certificate_Token_Contact extends CRM_Certificate_Token_AbstractCertif
           ->addSelect('employer_id')
           ->addWhere('id', '=', $contactId)
           ->addChain('employerAddress', \Civi\Api4\Address::get()
-            ->addSelect('street_address', 'supplemental_address_1', 'county_id:label', 'country_id:label', 'city')
+            ->addSelect('street_address', 'supplemental_address_1', 'county_id:label',
+              'country_id:label', 'state_province_id:label', 'city'
+            )
             ->addWhere('contact_id', '=', '$employer_id')
             ->addWhere('is_primary', '=', TRUE)
           )
@@ -84,6 +86,7 @@ class CRM_Certificate_Token_Contact extends CRM_Certificate_Token_AbstractCertif
         $contact["employerAddress"][0]["supplemental_address_1"],
         $contact["employerAddress"][0]["city"],
         $contact["employerAddress"][0]["county_id:label"],
+        $contact["employerAddress"][0]["state_province_id:label"],
         $contact["employerAddress"][0]["country_id:label"],
       ];
 

--- a/CRM/Certificate/Token/Contact.php
+++ b/CRM/Certificate/Token/Contact.php
@@ -46,7 +46,7 @@ class CRM_Certificate_Token_Contact extends CRM_Certificate_Token_AbstractCertif
     try {
       if (is_array($contactId)) {
         $contactId = $contactId[0];
-        $contact = \Civi\Api4\Contact::get()
+        $contact = \Civi\Api4\Contact::get(FALSE)
           ->addSelect('employer_id')
           ->addWhere('id', '=', $contactId)
           ->addChain('employerAddress', \Civi\Api4\Address::get()

--- a/certificate.php
+++ b/certificate.php
@@ -120,6 +120,7 @@ function certificate_civicrm_permission(&$permissions) {
 function _compucertificate_add_token_subscribers() {
   Civi::dispatcher()->addSubscriber(new CRM_Certificate_Token_Case());
   Civi::dispatcher()->addSubscriber(new CRM_Certificate_Token_Event());
+  Civi::dispatcher()->addSubscriber(new CRM_Certificate_Token_Contact());
   Civi::dispatcher()->addSubscriber(new CRM_Certificate_Token_Participant());
   Civi::dispatcher()->addSubscriber(new CRM_Certificate_Token_Membership());
   Civi::dispatcher()->addSubscriber(new CRM_Certificate_Token_Certificate());
@@ -142,6 +143,7 @@ function _compucertificate_getCaseIdFromUrlIfExist() {
 function certificate_civicrm_tokens(&$tokens) {
   $tokens[CRM_Certificate_Token_Case::TOKEN] = CRM_Certificate_Token_Case::prefixedEntityTokens();
   $tokens[CRM_Certificate_Token_Event::TOKEN] = CRM_Certificate_Token_Event::prefixedEntityTokens();
+  $tokens[CRM_Certificate_Token_Contact::TOKEN] = CRM_Certificate_Token_Contact::prefixedEntityTokens();
   $tokens[CRM_Certificate_Token_Participant::TOKEN] = CRM_Certificate_Token_Participant::prefixedEntityTokens();
   $tokens[CRM_Certificate_Token_Membership::TOKEN] = CRM_Certificate_Token_Membership::prefixedEntityTokens();
   $tokens[CRM_Certificate_Token_Certificate::TOKEN] = CRM_Certificate_Token_Certificate::prefixedEntityTokens();

--- a/tests/phpunit/CRM/Certificate/Token/ContactTest.php
+++ b/tests/phpunit/CRM/Certificate/Token/ContactTest.php
@@ -31,8 +31,8 @@ class CRM_Certificate_Token_ContactTest extends BaseHeadlessTest {
     $address = explode(", ", $res["employer_inline_address"]);
 
     // Ensure the order is as expected.
-    $this->assertEquals($address[0], $employer["address"]["supplemental_address_1"]);
-    $this->assertEquals($address[1], $employer["address"]["supplemental_address_2"]);
+    $this->assertEquals($address[0], $employer["address"]["street_address"]);
+    $this->assertEquals($address[1], $employer["address"]["supplemental_address_1"]);
     $this->assertEquals($address[2], $employer["address"]["city"]);
     $this->assertEquals($address[3], $country["name"]);
   }

--- a/tests/phpunit/CRM/Certificate/Token/ContactTest.php
+++ b/tests/phpunit/CRM/Certificate/Token/ContactTest.php
@@ -1,0 +1,40 @@
+<?php
+
+use Civi\Api4\Country;
+use CRM_Certificate_Test_Fabricator_Contact as ContactFabricator;
+
+/**
+ * Test case token fields are resolved
+ *
+ * @group headless
+ */
+class CRM_Certificate_Token_ContactTest extends BaseHeadlessTest {
+
+  use CRM_Certificate_Test_Helper_Case;
+
+  public function testCanResolveContactEmployerAddressTokenFields() {
+    $contactTokenSubscriber = new CRM_Certificate_Token_Contact([]);
+
+    $employer = ContactFabricator::fabricateWithAddress();
+    $contact = ContactFabricator::fabricate(['employer_id' => $employer['id']]);
+
+    $tokenValueEventMock = $this->createMock(\Civi\Token\Event\TokenValueEvent::class);
+    $tokenProcessorMock = $this->createMock(\Civi\Token\TokenProcessor::class);
+
+    $tokenValueEventMock->method('getTokenProcessor')->willReturn($tokenProcessorMock);
+    $tokenProcessorMock->method('getContextValues')->willReturn([$contact['id']]);
+
+    $country = Country::get(FALSE)->addWhere('id', '=', $employer['address']['country_id'])->execute()->first();
+    $res = $contactTokenSubscriber->prefetch($tokenValueEventMock);
+
+    $this->assertArrayHasKey("employer_inline_address", $res);
+    $address = explode(", ", $res["employer_inline_address"]);
+
+    // Ensure the order is as expected.
+    $this->assertEquals($address[0], $employer["address"]["supplemental_address_1"]);
+    $this->assertEquals($address[1], $employer["address"]["supplemental_address_2"]);
+    $this->assertEquals($address[2], $employer["address"]["city"]);
+    $this->assertEquals($address[3], $country["name"]);
+  }
+
+}


### PR DESCRIPTION
## Overview
In this PR we add support for a new token `{certificate_contact.employer_inline_address}`

## Before
No support for the token

## After
![certtt111t](https://user-images.githubusercontent.com/85277674/227498661-36206e66-9ad0-4152-99bd-5209b6988c53.gif)

![certttt](https://user-images.githubusercontent.com/85277674/227497763-4ef86bf5-9beb-4666-9a12-3f6f7faaaf68.gif)


## Technical Details
The token `{certificate_contact.employer_inline_address}` when used in a certificate context will resolve to the address of the contact employer. Contact here refers to the contact the downloaded certificate belongs to.



