### PR TITLE
FOSFAB-102: Gracefully handle any error that might occur while retrieving certificate

### DIFF
--- a/CRM/Certificate/Entity/Case.php
+++ b/CRM/Certificate/Entity/Case.php
@@ -16,37 +16,47 @@ class CRM_Certificate_Entity_Case extends CRM_Certificate_Entity_AbstractEntity 
    * {@inheritDoc}
    */
   public function getTypes() {
-    $result = civicrm_api3('CaseType', 'get', [
-      'sequential' => 1,
-      'is_active' => 1,
-      'return' => ["id"],
-      'options' => ['limit' => 0],
-    ]);
+    try {
+      $result = civicrm_api3('CaseType', 'get', [
+        'sequential' => 1,
+        'is_active' => 1,
+        'return' => ["id"],
+        'options' => ['limit' => 0],
+      ]);
 
-    if ($result["is_error"]) {
-      return NULL;
+      if ($result["is_error"]) {
+        return NULL;
+      }
+
+      return array_column($result["values"], 'id');
     }
-
-    return array_column($result["values"], 'id');
+    catch (\Throwable $th) {
+      return [];
+    }
   }
 
   /**
    * @inheritdoc
    */
   public function getStatuses() {
-    $result = civicrm_api3('OptionValue', 'get', [
-      'sequential' => 1,
-      'is_active' => 1,
-      'return' => ["value"],
-      'options' => ['limit' => 0],
-      'option_group_id' => "case_status",
-    ]);
+    try {
+      $result = civicrm_api3('OptionValue', 'get', [
+        'sequential' => 1,
+        'is_active' => 1,
+        'return' => ["value"],
+        'options' => ['limit' => 0],
+        'option_group_id' => "case_status",
+      ]);
 
-    if ($result["is_error"]) {
-      return NULL;
+      if ($result["is_error"]) {
+        return NULL;
+      }
+
+      return array_column($result["values"], 'value');
     }
-
-    return array_column($result["values"], 'value');
+    catch (\Throwable $th) {
+      return [];
+    }
   }
 
   /**
@@ -123,14 +133,21 @@ class CRM_Certificate_Entity_Case extends CRM_Certificate_Entity_AbstractEntity 
     $certificates = [];
 
     foreach ($configuredCertificates as $configuredCertificate) {
-      $result = civicrm_api3('CaseContact', 'get', [
-        'sequential' => 1,
-        'return' => ['case_id.case_type_id.title', 'case_id.status_id.label', 'case_id'],
-        'case_id.case_type_id' => $configuredCertificate['entity_type_id'],
-        'case_id.status_id' => $configuredCertificate['status_id'],
-        'contact_id' => $contactId,
-        'case_id.is_deleted' => 0,
-      ]);
+
+      $result = [];
+      try {
+        $result = civicrm_api3('CaseContact', 'get', [
+          'sequential' => 1,
+          'return' => ['case_id.case_type_id.title', 'case_id.status_id.label', 'case_id'],
+          'case_id.case_type_id' => $configuredCertificate['entity_type_id'],
+          'case_id.status_id' => $configuredCertificate['status_id'],
+          'contact_id' => $contactId,
+          'case_id.is_deleted' => 0,
+        ]);
+      }
+      catch (\Throwable $th) {
+        continue;
+      }
 
       if ($result['is_error']) {
         continue;

--- a/CRM/Certificate/Entity/Event.php
+++ b/CRM/Certificate/Entity/Event.php
@@ -16,36 +16,46 @@ class CRM_Certificate_Entity_Event extends CRM_Certificate_Entity_AbstractEntity
    * {@inheritdoc}
    */
   public function getTypes() {
-    $result = civicrm_api3('event', 'get', [
-      'sequential' => 1,
-      'is_active' => 1,
-      'return' => ["id"],
-      'options' => ['limit' => 0],
-    ]);
+    try {
+      $result = civicrm_api3('event', 'get', [
+        'sequential' => 1,
+        'is_active' => 1,
+        'return' => ["id"],
+        'options' => ['limit' => 0],
+      ]);
 
-    if ($result["is_error"]) {
-      return NULL;
+      if ($result["is_error"]) {
+        return NULL;
+      }
+
+      return array_column($result["values"], 'id');
     }
-
-    return array_column($result["values"], 'id');
+    catch (\Throwable $th) {
+      return [];
+    }
   }
 
   /**
    * {@inheritdoc}
    */
   public function getStatuses() {
-    $result = civicrm_api3('ParticipantStatusType', 'get', [
-      'sequential' => 1,
-      'is_active' => 1,
-      'return' => ["id"],
-      'options' => ['limit' => 0],
-    ]);
+    try {
+      $result = civicrm_api3('ParticipantStatusType', 'get', [
+        'sequential' => 1,
+        'is_active' => 1,
+        'return' => ["id"],
+        'options' => ['limit' => 0],
+      ]);
 
-    if ($result["is_error"]) {
-      return NULL;
+      if ($result["is_error"]) {
+        return NULL;
+      }
+
+      return array_column($result["values"], 'id');
     }
-
-    return array_column($result["values"], 'id');
+    catch (\Throwable $th) {
+      return [];
+    }
   }
 
   /**
@@ -160,7 +170,13 @@ class CRM_Certificate_Entity_Event extends CRM_Certificate_Entity_AbstractEntity
         $condition['participant_role_id'] = ['IN' => (array) $participantTypeId];
       }
 
-      $result = civicrm_api3('Participant', 'get', $condition);
+      $result = [];
+      try {
+        $result = civicrm_api3('Participant', 'get', $condition);
+      }
+      catch (\Throwable $th) {
+        continue;
+      }
 
       if ($result['is_error']) {
         continue;

--- a/CRM/Certificate/Entity/Membership.php
+++ b/CRM/Certificate/Entity/Membership.php
@@ -16,36 +16,46 @@ class CRM_Certificate_Entity_Membership extends CRM_Certificate_Entity_AbstractE
    * {@inheritDoc}
    */
   public function getTypes() {
-    $result = civicrm_api3('MembershipType', 'get', [
-      'sequential' => 1,
-      'is_active' => 1,
-      'return' => ["id"],
-      'options' => ['limit' => 0],
-    ]);
+    try {
+      $result = civicrm_api3('MembershipType', 'get', [
+        'sequential' => 1,
+        'is_active' => 1,
+        'return' => ["id"],
+        'options' => ['limit' => 0],
+      ]);
 
-    if ($result["is_error"]) {
-      return NULL;
+      if ($result["is_error"]) {
+        return NULL;
+      }
+
+      return array_column($result["values"], 'id');
     }
-
-    return array_column($result["values"], 'id');
+    catch (\Throwable $th) {
+      return [];
+    }
   }
 
   /**
    * {@inheritdoc}
    */
   public function getStatuses() {
-    $result = civicrm_api3('MembershipStatus', 'get', [
-      'sequential' => 1,
-      'is_active' => 1,
-      'return' => ["id"],
-      'options' => ['limit' => 0],
-    ]);
+    try {
+      $result = civicrm_api3('MembershipStatus', 'get', [
+        'sequential' => 1,
+        'is_active' => 1,
+        'return' => ["id"],
+        'options' => ['limit' => 0],
+      ]);
 
-    if ($result["is_error"]) {
-      return NULL;
+      if ($result["is_error"]) {
+        return NULL;
+      }
+
+      return array_column($result["values"], 'id');
     }
-
-    return array_column($result["values"], 'id');
+    catch (\Throwable $th) {
+      return [];
+    }
   }
 
   /**
@@ -137,7 +147,13 @@ class CRM_Certificate_Entity_Membership extends CRM_Certificate_Entity_AbstractE
         $condition['membership_type_id'] = $configuredCertificate['entity_type_id'];
       }
 
-      $result = civicrm_api3('Membership', 'get', $condition);
+      $result = [];
+      try {
+        $result = civicrm_api3('Membership', 'get', $condition);
+      }
+      catch (\Throwable $th) {
+        continue;
+      }
 
       if ($result['is_error']) {
         continue;


### PR DESCRIPTION
## Overview
This PR adds a try-catch block to methods that retrieve entity types and statuses, this is needed because it's possible that the entity type a certificate is attached to has been deleted, causing the API to throw an exception. The exception thrown is not an issue in CiviCRM itself as such exceptions are converted to alert messages, but they can break an SSP page. we simply wrap those API calls that are related to ssp_certificate functionality into the try-catch block.