### PR TITLE
CST-174: Hide participant role description

### DIFF
--- a/templates/CRM/Certificate/Form/CertificateConfigure.tpl
+++ b/templates/CRM/Certificate/Form/CertificateConfigure.tpl
@@ -92,6 +92,7 @@
           .crmEntityRef({
             entity: 'OptionValue',
             api: {
+              description_field: null,
               params: {active: true, option_group_id: 'participant_role'}
             },
             select: {


### PR DESCRIPTION
## Overview
This PR hides the participant role description when creating a new certificate configuration

## Before
The description of the participant roles is displayed 
<img width="673" alt="Screenshot 2023-06-13 at 15 40 40" src="https://github.com/compucorp/uk.co.compucorp.certificate/assets/85277674/33036382-aa0f-44fa-9bd7-d10a88b6540e">


## After
The description of the participant roles is not displayed
<img width="657" alt="Screenshot 2023-06-13 at 15 40 25" src="https://github.com/compucorp/uk.co.compucorp.certificate/assets/85277674/0afaa8e3-0ff9-44aa-ba4b-56880a750c47">


## Comment
The reason for concealing the participant role descriptions is that they are created using a rich text editor, resulting in the presence of HTML tags when shown in the select field.