### PR TITLE
MMB-271: Add Certificate Validity Date Tokens

### DIFF
--- a/CRM/Certificate/Token/AbstractCertificateToken.php
+++ b/CRM/Certificate/Token/AbstractCertificateToken.php
@@ -102,7 +102,8 @@ abstract class CRM_Certificate_Token_AbstractCertificateToken extends AbstractTo
     }
 
     if ($value) {
-      $row->tokens($prefix, $field, $value);
+      $row->format('text/plain')->tokens($prefix, $field, $value);
+      $row->format('text/html')->tokens($prefix, $field, $value);
     }
   }
 

--- a/CRM/Certificate/Token/Certificate.php
+++ b/CRM/Certificate/Token/Certificate.php
@@ -21,6 +21,8 @@ class CRM_Certificate_Token_Certificate extends CRM_Certificate_Token_AbstractCe
     "name" => "Certificate Name",
     "start_date" => "Certificate Start Date",
     "end_date" => "Certificate End Date",
+    "valid_from" => "Certificate Valid From Date",
+    "valid_to" => "Certificate Valid To Date",
   ];
 
   public function __construct($tokenNames = []) {
@@ -55,7 +57,7 @@ class CRM_Certificate_Token_Certificate extends CRM_Certificate_Token_AbstractCe
           return $resolvedTokens;
         }
 
-        $this->resolveFields($certificate, $resolvedTokens);
+        $this->resolveFields($certificate, $this->getMembershipDates($e), $resolvedTokens);
       }
     }
     catch (Exception $e) {
@@ -65,16 +67,53 @@ class CRM_Certificate_Token_Certificate extends CRM_Certificate_Token_AbstractCe
     return $resolvedTokens;
   }
 
+  private function getMembershipDates(TokenValueEvent $e): array {
+    $contactIds = $e->getTokenProcessor()->getContextValues('contactId');
+    $contactId = (is_array($contactIds) && !empty($contactIds[0])) ? $contactIds[0] : 0;
+
+    $membershipRows = civicrm_api3(
+      'membership',
+      'get',
+      [
+        'version' => 3,
+        'return' => ['start_date', 'end_date'],
+        'contact_id' => $contactId,
+        'status_id' => 2,
+        'sequential' => 1,
+        'options' => ['sort' => 'end_date desc', 'limit' => 1],
+      ]
+    );
+
+    return !empty($membershipRows['values'][0])
+      ? $membershipRows['values'][0]
+      : ['start_date' => '', 'end_date' => ''];
+  }
+
   /**
    * Resolve the value of ceritificate configuration token fields.
    *
    * @param CRM_Certificate_DAO_CompuCertificate $certificate
+   * @param array $membershipDates
    * @param array &$resolvedTokens
    */
-  private function resolveFields($certificate, &$resolvedTokens) {
+  private function resolveFields($certificate, array $membershipDates, &$resolvedTokens) {
+    $membershipStartTimestamp = !empty($membershipDates['start_date']) ? strtotime($membershipDates['start_date']) : '';
+    $membershipEndTimestamp = !empty($membershipDates['end_date']) ? strtotime($membershipDates['end_date']) : '';
+    $certificateValidityStartTimestamp = !empty($certificate->min_valid_from_date) ? strtotime($certificate->min_valid_from_date) : '';
+    $certificateValidityEndTimestamp = !empty($certificate->max_valid_through_date) ? strtotime($certificate->max_valid_through_date) : '';
+
+    $validityStartDate = empty($certificateValidityStartTimestamp) || $membershipStartTimestamp > $certificateValidityStartTimestamp ?
+      $membershipDates['start_date'] : (string) $certificate->min_valid_from_date;
+    $validityEndDate = empty($certificateValidityEndTimestamp) || (!empty($membershipEndTimestamp) && $certificateValidityEndTimestamp > $membershipEndTimestamp) ?
+      $membershipDates['end_date'] : (string) $certificate->max_valid_through_date;
+
     $resolvedTokens['name'] = $certificate->name;
     $resolvedTokens['start_date'] = CRM_Utils_Date::customFormat($certificate->start_date, '%e/%b/%Y');
     $resolvedTokens['end_date'] = CRM_Utils_Date::customFormat($certificate->end_date, '%e/%b/%Y');
+    $resolvedTokens['valid_from'] = !empty($validityStartDate)
+      ? CRM_Utils_Date::customFormat($validityStartDate, '%e/%b/%Y') : '';
+    $resolvedTokens['valid_to'] = !empty($validityEndDate)
+      ? CRM_Utils_Date::customFormat($validityEndDate, '%e/%b/%Y') : '';
   }
 
 }

--- a/CRM/Certificate/Token/Certificate.php
+++ b/CRM/Certificate/Token/Certificate.php
@@ -78,7 +78,7 @@ class CRM_Certificate_Token_Certificate extends CRM_Certificate_Token_AbstractCe
         'version' => 3,
         'return' => ['start_date', 'end_date'],
         'contact_id' => $contactId,
-        'status_id' => 2,
+        'status_id' => 'Current',
         'sequential' => 1,
         'options' => ['sort' => 'end_date desc', 'limit' => 1],
       ]


### PR DESCRIPTION
## Overview
Add two new tokens for certificate validity dates 

1. “Valid From Date” {certificate.valid_from}
The latter of 1) the “Min Valid From Date” as configured for the certificate and 2) the users membership start date.
If the “Min Valid From Date” is null then we use the membership start date. 

2. “Valid To Date” {certificate.valid_to}
The earlier of 1) the “Max Valid Through Date” as configured for the certificate and 2) the users membership end date.
If the “Max Valid Through Date” is null then we use the membership end date.  

## Before
There were no certificate validity tokens.

## After
![Screenshot from 2023-11-03 17-47-44](https://github.com/compucorp/uk.co.compucorp.certificate/assets/147053234/533643d6-d7be-4f12-8f78-4c379e2cae8a)
