### PR TITLE
MMB-302: Add help text to certificate download type field

### DIFF
--- a/CRM/Certificate/Form/CertificateConfigure.php
+++ b/CRM/Certificate/Form/CertificateConfigure.php
@@ -180,7 +180,7 @@ class CRM_Certificate_Form_CertificateConfigure extends CRM_Core_Form {
       ],
     ]);
 
-    $elementWithHelpTexts = ['relationship_types', 'min_valid_from_date', 'max_valid_through_date'];
+    $elementWithHelpTexts = ['relationship_types', 'min_valid_from_date', 'max_valid_through_date', 'download_type'];
 
     $this->assign('help', $elementWithHelpTexts);
     $this->assign('elementNames', $this->getRenderableElementNames());

--- a/templates/CRM/Certificate/Form/CertificateConfigure.hlp
+++ b/templates/CRM/Certificate/Form/CertificateConfigure.hlp
@@ -56,3 +56,7 @@
     </li>
   <ol>
 {/htxt}
+
+{htxt id="download_type"}
+  {ts}Specify whether the certificate should be generated dynamically from a CiviCRM message template or be granted access to a downloadable file.{/ts}
+{/htxt}


### PR DESCRIPTION
## Overview
Add help text to certificate download type field

## Before

![image](https://github.com/compucorp/uk.co.compucorp.certificate/assets/85277674/ef2d7916-73bf-4960-92ed-4375685b9e0b)



## After
<img width="1168" alt="Screenshot 2023-12-12 at 10 25 22" src="https://github.com/compucorp/uk.co.compucorp.certificate/assets/85277674/fc8f8b78-c595-454e-8d69-c83df780187b">
