### PR TITLE
FOSFA-282: Support configuration of similar Membership certificate

### DIFF
--- a/CRM/Certificate/Entity/Membership.php
+++ b/CRM/Certificate/Entity/Membership.php
@@ -169,6 +169,7 @@ class CRM_Certificate_Entity_Membership extends CRM_Certificate_Entity_AbstractE
           'start_date' => $configuredCertificate['start_date'],
           'linked_to' => $membership['membership_name'],
           'download_link' => $this->getCertificateDownloadUrl($membership['id'], $contactId, TRUE),
+          'configuration_id' => $configuredCertificate['certificate_id'],
         ];
         array_push($certificates, $certificate);
       });

--- a/CRM/Certificate/Hook/PageRun/EventPageTab.php
+++ b/CRM/Certificate/Hook/PageRun/EventPageTab.php
@@ -32,7 +32,7 @@ class CRM_Certificate_Hook_PageRun_EventPageTab {
       $downloadUrl = htmlspecialchars_decode(CRM_Utils_System::url('civicrm/certificates/event', $query));
       CRM_Core_Resources::singleton()
         ->addScriptFile("uk.co.compucorp.certificate", "./js/eventDownloadButton.js");
-      Civi::resources()->addVars(E::SHORT_NAME, ['download_url' => $downloadUrl]);
+      Civi::resources()->addVars(E::SHORT_NAME, ['download_url' => [$downloadUrl]]);
     }
   }
 

--- a/CRM/Certificate/Hook/PageRun/MemberPageTab.php
+++ b/CRM/Certificate/Hook/PageRun/MemberPageTab.php
@@ -21,12 +21,14 @@ class CRM_Certificate_Hook_PageRun_MemberPageTab {
 
     $certificateType = CRM_Certificate_Enum_CertificateType::MEMBERSHIPS;
     $entity = CRM_Certificate_Entity_EntityFactory::create($certificateType);
-    $configuredCertificate = $entity->getCertificateConfiguration($id, $contactId);
+    $configuredCertificates = $entity->getCertificateConfiguration($id, $contactId, TRUE);
 
-    if ($configuredCertificate) {
-      $downloadUrl = $entity->getCertificateDownloadUrl($id, $contactId);
+    if (!empty($configuredCertificates)) {
+      foreach ($configuredCertificates as $certificate) {
+        $downloadUrls[] = sprintf("%s&ccid=%s", $entity->getCertificateDownloadUrl($id, $contactId), $certificate->id);
+      }
 
-      Civi::resources()->addVars(E::SHORT_NAME, ['download_url' => $downloadUrl]);
+      Civi::resources()->addVars(E::SHORT_NAME, ['download_url' => $downloadUrls]);
       Civi::resources()->addScriptFile(E::LONG_NAME, "/js/compucertificate.js", 0);
       Civi::resources()->addScriptFile(E::LONG_NAME, "./js/memberDownloadButton.js", 1);
     }

--- a/CRM/Certificate/Service/Certificate.php
+++ b/CRM/Certificate/Service/Certificate.php
@@ -17,7 +17,8 @@ class CRM_Certificate_Service_Certificate {
   public function store($values) {
     $result = NULL;
 
-    if ($this->configurationExist($values)) {
+    $duplicateSupportEntity = [CRM_Certificate_Enum_CertificateType::MEMBERSHIPS];
+    if (!in_array($values['type'], $duplicateSupportEntity) && $this->configurationExist($values)) {
       throw new CRM_Certificate_Exception_ConfigurationExistException();
     }
 

--- a/js/compucertificate.js
+++ b/js/compucertificate.js
@@ -15,8 +15,15 @@ window.downloadLink = function () {
     `<span class="ui-button-icon ui-icon crm-i fa-print"></span>
     <span class="ui-button-icon-space">Print Certificate</span>`
   );
+
+  let url = '';
+  let count = 0;
+  CRM.vars.certificate.download_url.forEach(downloadUrl => {
+    url += ' setTimeout(function(){ window.open("' + downloadUrl + '"); }, ' + (500 * count++) + '); ';
+  });
+
   btn.setAttribute('type', 'button');
-  btn.setAttribute('onclick', "window.open('" + CRM.vars.certificate.download_url + "')");
+  btn.setAttribute('onclick', url);
   btn.setAttribute('target', '_blank');
   btn.classList.add('ui-button', 'ui-corner-all', 'ui-widget');
   btn.style.marginRight = '5px';

--- a/tests/phpunit/CRM/Certificate/Service/CertificateMembershipTest.php
+++ b/tests/phpunit/CRM/Certificate/Service/CertificateMembershipTest.php
@@ -58,8 +58,7 @@ class CRM_Certificate_Service_CertificateMembershipTest extends BaseHeadlessTest
    * Test that duplicate certifiacte configuration
    * cannot be created for the same entity.
    */
-  public function testExceptionThrownForDuplicateCertificateMembershipConfiguration() {
-    $this->expectException(CRM_Certificate_Exception_ConfigurationExistException::class);
+  public function testExceptionNotThrownForDuplicateCertificateMembershipConfiguration() {
     $statuses = CRM_Certificate_Test_Fabricator_MembershipStatus::fabricate()['id'];
     $types = CRM_Certificate_Test_Fabricator_MembershipType::fabricate()['id'];
 
@@ -72,8 +71,11 @@ class CRM_Certificate_Service_CertificateMembershipTest extends BaseHeadlessTest
       'end_date' => date('Y-m-d'),
     ];
 
-    $this->createCertificate($values);
-    $this->createCertificate($values);
+    $cert1 = $this->createCertificate($values);
+    $cert2 = $this->createCertificate($values);
+
+    $this->assertNotEmpty($cert1);
+    $this->assertNotEmpty($cert2);
   }
 
   /**


### PR DESCRIPTION
## Overview
Previously when a user attempted to create a certificate for an entity with the same configuration value, a Certificate Exist Exception was thrown, in this PR we now allow users to create a certificate for membership entity with similar configurations.

## Before
Error Message is thrown to the User for duplicate membership certificate
`A certificate configuration exist for the entity that satisfies either the selected status or type`

![222aaaaaaaaaa](https://github.com/compucorp/uk.co.compucorp.certificate/assets/85277674/8402d016-2bec-4386-a3f7-cf98caec2aec)



## After
Error Message is now thrown to the User for duplicate membership certificate

![3333aaaaaaaaaa](https://github.com/compucorp/uk.co.compucorp.certificate/assets/85277674/8b76cc5f-da86-4fd5-835f-aee7c5f8994c)

## After
Users can download multiple certificates by clicking on the `Print Certificate` button in the membership view.
![4444](https://github.com/compucorp/uk.co.compucorp.certificate/assets/85277674/9aa73b87-7d75-4d79-87bd-116f0de06b3a)
