### PR TITLE
MMB-437: Support Different Date Formats For Tokens

### DIFF
--- a/CRM/Certificate/Service/CertificateMembership.php
+++ b/CRM/Certificate/Service/CertificateMembership.php
@@ -30,7 +30,7 @@ class CRM_Certificate_Service_CertificateMembership extends CRM_Certificate_Serv
       $renewalDate = $renewalDate === NULL || $membershipDate < $renewalDate ? $membershipDate : $renewalDate;
     }
 
-    return $renewalDate ? CRM_Utils_Date::customFormat(date('Y-m-d', $renewalDate), '%e/%b/%Y') : '';
+    return $renewalDate ? date('Y-m-d', $renewalDate) : '';
   }
 
   private function getValidMembershipsForCertificate(int $certificateId, int $contactId): array {

--- a/CRM/Certificate/Token/Case.php
+++ b/CRM/Certificate/Token/Case.php
@@ -99,11 +99,13 @@ class CRM_Certificate_Token_Case extends CRM_Certificate_Token_AbstractCertifica
     }
 
     $caseStatus = CRM_Case_PseudoConstant::caseStatus('label', TRUE, 'AND value = ' . $case['status_id']);
+    $startDate = CRM_Utils_Array::value('start_date', $case, '');
+    $endDate = CRM_Utils_Array::value('end_date', $case, '');
 
     $resolvedTokens['id'] = CRM_Utils_Array::value('id', $case, '');
     $resolvedTokens['subject'] = CRM_Utils_Array::value('subject', $case, '');
-    $resolvedTokens['start_date'] = CRM_Utils_Date::customFormat(CRM_Utils_Array::value('start_date', $case, ''));
-    $resolvedTokens['end_date'] = CRM_Utils_Date::customFormat(CRM_Utils_Array::value('end_date', $case, ''));
+    $resolvedTokens['start_date'] = !empty($startDate) ? new \DateTime($startDate) : '';
+    $resolvedTokens['end_date'] = !empty($endDate) ? new \DateTime($endDate) : '';
     $resolvedTokens['created_date'] = CRM_Utils_Date::customFormat(CRM_Utils_Array::value('created_date', $case, ''));
     $resolvedTokens['role'] = $role;
     $resolvedTokens['status'] = array_pop($caseStatus) ?? '';

--- a/CRM/Certificate/Token/Certificate.php
+++ b/CRM/Certificate/Token/Certificate.php
@@ -91,21 +91,22 @@ class CRM_Certificate_Token_Certificate extends CRM_Certificate_Token_AbstractCe
       $membershipEndTimestamp = !empty($membershipDates['endDate']) ? strtotime($membershipDates['endDate']) : '';
       $certificateValidityStartTimestamp = !empty($certificate->min_valid_from_date) ? strtotime($certificate->min_valid_from_date) : '';
       $certificateValidityEndTimestamp = !empty($certificate->max_valid_through_date) ? strtotime($certificate->max_valid_through_date) : '';
+      $membershipRenewalDate = $service->getMembershipRenewalDate($certificate->id, $contactId);
 
-      $resolvedTokens['rolling_start_or_renewal_date'] = $service->getMembershipRenewalDate($certificate->id, $contactId);
+      $resolvedTokens['rolling_start_or_renewal_date'] = !empty($membershipRenewalDate) ? new \DateTime($membershipRenewalDate) : '';
       $validityStartDate = empty($certificateValidityStartTimestamp) || $membershipStartTimestamp > $certificateValidityStartTimestamp ?
         $membershipDates['startDate'] : (string) $certificate->min_valid_from_date;
       $validityEndDate = empty($certificateValidityEndTimestamp) || (!empty($membershipEndTimestamp) && $certificateValidityEndTimestamp > $membershipEndTimestamp) ?
         $membershipDates['endDate'] : (string) $certificate->max_valid_through_date;
       $resolvedTokens['valid_from'] = !empty($validityStartDate)
-        ? CRM_Utils_Date::customFormat($validityStartDate, '%e/%b/%Y') : '';
+        ? new \DateTime($validityStartDate) : '';
       $resolvedTokens['valid_to'] = !empty($validityEndDate)
-        ? CRM_Utils_Date::customFormat($validityEndDate, '%e/%b/%Y') : '';
+        ? new \DateTime($validityEndDate) : '';
     }
 
     $resolvedTokens['name'] = $certificate->name;
-    $resolvedTokens['start_date'] = CRM_Utils_Date::customFormat($certificate->start_date, '%e/%b/%Y');
-    $resolvedTokens['end_date'] = CRM_Utils_Date::customFormat($certificate->end_date, '%e/%b/%Y');
+    $resolvedTokens['start_date'] = new \DateTime($certificate->start_date);
+    $resolvedTokens['end_date'] = new \DateTime($certificate->end_date);
   }
 
 }

--- a/CRM/Certificate/Token/Event.php
+++ b/CRM/Certificate/Token/Event.php
@@ -118,8 +118,8 @@ class CRM_Certificate_Token_Event extends CRM_Certificate_Token_AbstractCertific
     ]);
     $tokens['info_url']['text/html'] = \CRM_Utils_System::href('civicrm/event/info', 'reset=1&id=' . $eventId, TRUE, NULL, TRUE);
     $tokens['registration_url']['text/html'] = \CRM_Utils_System::href('civicrm/event/register', 'reset=1&id=' . $eventId, TRUE, NULL, TRUE);
-    $tokens['start_date']['text/html'] = !empty($event['start_date']) ? CRM_Utils_Date::customFormat($event['start_date']) : '';
-    $tokens['end_date']['text/html'] = !empty($event['end_date']) ? CRM_Utils_Date::customFormat($event['end_date']) : '';
+    $tokens['start_date']['text/html'] = !empty($event['start_date']) ? new \DateTime($event['start_date']) : '';
+    $tokens['end_date']['text/html'] = !empty($event['end_date']) ? new \DateTime($event['end_date']) : '';
     $tokens['event_type']['text/html'] = CRM_Core_PseudoConstant::getLabel('CRM_Event_BAO_Event', 'event_type_id', $event['event_type_id']);
     $tokens['contact_phone']['text/html'] = $event['phone.phone'] ?? '';
     $tokens['contact_email']['text/html'] = $event['email.email'] ?? '';

--- a/CRM/Certificate/Token/Membership.php
+++ b/CRM/Certificate/Token/Membership.php
@@ -94,7 +94,7 @@ class CRM_Certificate_Token_Membership extends CRM_Certificate_Token_AbstractCer
       ];
 
       if (in_array($k, $dateFields)) {
-        $v = CRM_Utils_Date::customFormat($v);
+        $v = !empty($v) ? new \DateTime($v) : '';
       }
     });
 

--- a/CRM/Certificate/Token/Participant.php
+++ b/CRM/Certificate/Token/Participant.php
@@ -109,7 +109,7 @@ class CRM_Certificate_Token_Participant extends CRM_Certificate_Token_AbstractCe
       ];
 
       if (in_array($k, $dateFields)) {
-        $v = CRM_Utils_Date::customFormat($v);
+        $v = !empty($v) ? new \DateTime($v) : '';
       }
 
       if (is_array($v)) {

--- a/tests/phpunit/CRM/Certificate/Service/CertificateEventGeneratorTest.php
+++ b/tests/phpunit/CRM/Certificate/Service/CertificateEventGeneratorTest.php
@@ -66,7 +66,7 @@ class CRM_Certificate_Service_EventCertificateGeneratorTest extends BaseHeadless
 
     $this->assertStringContainsString($contact["display_name"], $result["html"]);
     $this->assertStringContainsString($event["title"], $result["html"]);
-    $this->assertStringContainsString(CRM_Utils_Date::customFormat($event["start_date"]), $result["html"]);
+    $this->assertStringContainsString(CRM_Utils_Date::customFormat($event["start_date"], NULL, ['d']), $result["html"]);
   }
 
   private function getMsgContent($extra = "") {


### PR DESCRIPTION
## Overview
The current implementation for values of date tokens only support a fix format which is something like 31/Dec/2024. This pr adds the support for most of the different date formats that are supported by [this](https://www.php.net/manual/en/function.strftime.php) function.

## Before
Dates were being provided in just a single format for certificate date token values.

## After
Now we can utilize [this](https://docs.civicrm.org/user/en/latest/common-workflows/tokens-and-mail-merge/#date) date formatting for certificate date tokens.

## Technical Details
Currently we are providing string values for tokens, this pr changes the values to be a DateTime object so that civi formats the dates according to the given format. If no format is given then the default format that is defined in admin settings will be used