### PR TITLE
MMB-501: Add Insurance Premium Tokens

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -54,6 +54,7 @@ jobs:
           git clone --depth 1 https://github.com/civicrm/org.civicrm.shoreditch.git
           git clone --depth 1 -b master --no-single-branch https://github.com/compucorp/uk.co.compucorp.civicase.git
           git clone --depth 1 -b master https://github.com/compucorp/uk.co.compucorp.usermenu.git
+          git clone --depth 1 -b master https://github.com/compucorp/io.compuco.financeextras.git
 
       - name: Setup Test DB
         run: echo "CREATE DATABASE civicrm_test;" | mysql -u root --password=root --host=mysql

--- a/info.xml
+++ b/info.xml
@@ -28,6 +28,7 @@
   </civix>
   <requires>
     <ext>uk.co.compucorp.civicase</ext>
+    <ext>io.compuco.financeextras</ext>
   </requires>
   <mixins>
     <mixin>ang-php@1.0.0</mixin>


### PR DESCRIPTION
## Overview
This pr creates three new tokens related to insurance premium amounts.

- Token 1: Insurance Premium (excl IPT): {certificate_membership.insurance_premium_ex_ipt}
- 
- Token 2: Insurance Premium (IPT): {certificate_membership.insurance_premium_ipt_only}
- 
- Token 3: Insurance Premium (incl IPT): {certificate_membership.insurance_premium_inc_ipt}

## Before
Tokens did not exist

## After
<img width="1792" alt="Screenshot 2024-11-13 at 2 07 10 PM" src="https://github.com/user-attachments/assets/5b2c62ec-128a-4cfe-adfb-3f3e2a2a7dab">
