### PR TITLE
CIVIMM-293: Fix permission label

### DIFF
--- a/certificate.php
+++ b/certificate.php
@@ -60,8 +60,8 @@ function certificate_civicrm_navigationMenu(&$menu) {
  */
 function certificate_civicrm_permission(&$permissions) {
   $permissions['configure certificates'] = [
-    ts('CompuCertificate: configure certificates'),
-    ts('User can configure which message templates can be downloaded as certificates.'),
+    'label' => ts('CompuCertificate: configure certificates'),
+    'description' => ts('User can configure which message templates can be downloaded as certificates.'),
   ];
 }
 


### PR DESCRIPTION
## Overview
This PR fixes the permission label warning

> [PHP User Deprecation] Permission 'configure certificates' should be declared with 'label' and 'description' keys. See https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_permission/ Caller: CRM_Core_Permission::assembleBasicPermissions at /var/www/default/htdocs/httpdocs/profiles/compuclient/modules/contrib/civicrm/CRM/Core/Error.php:1132







