### PR TITLE
MMMM-190: Filter membership certificates by min/max valid dates

### DIFF
--- a/CRM/Certificate/BAO/CompuCertificate.php
+++ b/CRM/Certificate/BAO/CompuCertificate.php
@@ -93,7 +93,7 @@ class CRM_Certificate_BAO_CompuCertificate extends CRM_Certificate_DAO_CompuCert
     $certificateBAO->whereAdd('contact_id_a = ' . $contactId);
     $certificateBAO->whereDateIsValid();
     $certificateBAO->selectAdd();
-    $certificateBAO->selectAdd(self::$_tableName . '.id as certificate_id, ' . self::$_tableName . '.start_date, ' . self::$_tableName . '.end_date, name, entity, entity_type_id, status_id, template_id, download_format, contact_id_b as related_contact, contact_id_a as contact');
+    $certificateBAO->selectAdd(self::$_tableName . '.id as certificate_id, ' . self::$_tableName . '.start_date, ' . self::$_tableName . '.end_date, ' . self::$_tableName . '.min_valid_from_date, ' . self::$_tableName . '.max_valid_through_date, name, entity, entity_type_id, status_id, template_id, download_format, contact_id_b as related_contact, contact_id_a as contact');
     $certificateBAO->find();
 
     $configuredCertificates = $certificateBAO->fetchAll();

--- a/CRM/Certificate/Entity/AbstractEntity.php
+++ b/CRM/Certificate/Entity/AbstractEntity.php
@@ -119,7 +119,7 @@ abstract class CRM_Certificate_Entity_AbstractEntity {
 
       $results = [];
       while ($certificateBAO->fetch()) {
-        if (!empty($certificateBAO->id) && $this->isCertificateValidForAnEntity($certificateBAO, $contactId)) {
+        if (!empty($certificateBAO->id) && $this->isCertificateValidForAnEntity($certificateBAO, $contactId, $entityId)) {
           $results[] = clone $certificateBAO;
         }
       }
@@ -185,10 +185,12 @@ abstract class CRM_Certificate_Entity_AbstractEntity {
    *  Certificate.
    * @param int $contactId
    *  Contact id.
+   * @param int $entityId
+   *  Id of the specific entity the certificate is requested for.
    *
    * @return bool
    */
-  protected function isCertificateValidForAnEntity(\CRM_Certificate_BAO_CompuCertificate $certificate, int $contactId) {
+  protected function isCertificateValidForAnEntity(\CRM_Certificate_BAO_CompuCertificate $certificate, int $contactId, int $entityId = NULL) {
     return TRUE;
   }
 

--- a/CRM/Certificate/Entity/Membership.php
+++ b/CRM/Certificate/Entity/Membership.php
@@ -160,7 +160,7 @@ class CRM_Certificate_Entity_Membership extends CRM_Certificate_Entity_AbstractE
       }
 
       array_walk($result['values'], function ($membership) use (&$certificates, $configuredCertificate, $contactId) {
-        if (!$this->membershipDatesOverlapCertificate($membership, $configuredCertificate)) {
+        if (!$this->membershipDatesOverlapCertificate($membership, $configuredCertificate['min_valid_from_date'] ?? NULL, $configuredCertificate['max_valid_through_date'] ?? NULL)) {
           return;
         }
         $certificate = [
@@ -182,19 +182,15 @@ class CRM_Certificate_Entity_Membership extends CRM_Certificate_Entity_AbstractE
   }
 
   /**
-   * Checks whether a membership overlaps the certificate's validity window.
-   *
-   * The membership end_date must be on or after Min Valid From and the
-   * start_date on or before Max Valid Through. Either bound may be NULL
-   * meaning unbounded.
+   * Checks whether a membership's active period overlaps a certificate window.
    */
-  private function membershipDatesOverlapCertificate(array $membership, array $configuredCertificate): bool {
-    $minFrom = !empty($configuredCertificate['min_valid_from_date']) ? strtotime($configuredCertificate['min_valid_from_date']) : NULL;
+  private function membershipDatesOverlapCertificate(array $membership, $minValidFromDate, $maxValidThroughDate): bool {
+    $minFrom = !empty($minValidFromDate) ? strtotime($minValidFromDate) : NULL;
     if ($minFrom && !empty($membership['end_date']) && strtotime($membership['end_date']) < $minFrom) {
       return FALSE;
     }
 
-    $maxThrough = !empty($configuredCertificate['max_valid_through_date']) ? strtotime($configuredCertificate['max_valid_through_date']) : NULL;
+    $maxThrough = !empty($maxValidThroughDate) ? strtotime($maxValidThroughDate) : NULL;
     if ($maxThrough && !empty($membership['start_date']) && strtotime($membership['start_date']) > $maxThrough) {
       return FALSE;
     }
@@ -223,11 +219,23 @@ class CRM_Certificate_Entity_Membership extends CRM_Certificate_Entity_AbstractE
   /**
    * @inheritDoc
    */
-  protected function isCertificateValidForAnEntity(\CRM_Certificate_BAO_CompuCertificate $certificate, int $contactId) {
-    $membershipDates = (new CRM_Certificate_Service_CertificateMembership())->getMembershipDates($certificate->id, $contactId);
+  protected function isCertificateValidForAnEntity(\CRM_Certificate_BAO_CompuCertificate $certificate, int $contactId, int $entityId = NULL) {
+    if (empty($entityId)) {
+      return TRUE;
+    }
 
-    return ($membershipDates['startDate'] === NULL || $certificate->max_valid_through_date === NULL || $membershipDates['startDate'] <= $certificate->max_valid_through_date)
-      && ($membershipDates['endDate'] === NULL || $certificate->min_valid_from_date === NULL || $membershipDates['endDate'] >= $certificate->min_valid_from_date);
+    $membership = \Civi\Api4\Membership::get(FALSE)
+      ->addSelect('start_date', 'end_date')
+      ->addWhere('id', '=', $entityId)
+      ->addWhere('contact_id', '=', $contactId)
+      ->execute()
+      ->first();
+
+    if (empty($membership)) {
+      return FALSE;
+    }
+
+    return $this->membershipDatesOverlapCertificate($membership, $certificate->min_valid_from_date, $certificate->max_valid_through_date);
   }
 
 }

--- a/CRM/Certificate/Entity/Membership.php
+++ b/CRM/Certificate/Entity/Membership.php
@@ -160,6 +160,9 @@ class CRM_Certificate_Entity_Membership extends CRM_Certificate_Entity_AbstractE
       }
 
       array_walk($result['values'], function ($membership) use (&$certificates, $configuredCertificate, $contactId) {
+        if (!$this->membershipDatesOverlapCertificate($membership, $configuredCertificate)) {
+          return;
+        }
         $certificate = [
           'membership_id' => $membership['id'],
           'name' => $configuredCertificate['name'],
@@ -176,6 +179,27 @@ class CRM_Certificate_Entity_Membership extends CRM_Certificate_Entity_AbstractE
     }
 
     return $certificates;
+  }
+
+  /**
+   * Checks whether a membership overlaps the certificate's validity window.
+   *
+   * The membership end_date must be on or after Min Valid From and the
+   * start_date on or before Max Valid Through. Either bound may be NULL
+   * meaning unbounded.
+   */
+  private function membershipDatesOverlapCertificate(array $membership, array $configuredCertificate): bool {
+    $minFrom = !empty($configuredCertificate['min_valid_from_date']) ? strtotime($configuredCertificate['min_valid_from_date']) : NULL;
+    if ($minFrom && !empty($membership['end_date']) && strtotime($membership['end_date']) < $minFrom) {
+      return FALSE;
+    }
+
+    $maxThrough = !empty($configuredCertificate['max_valid_through_date']) ? strtotime($configuredCertificate['max_valid_through_date']) : NULL;
+    if ($maxThrough && !empty($membership['start_date']) && strtotime($membership['start_date']) > $maxThrough) {
+      return FALSE;
+    }
+
+    return TRUE;
   }
 
   /**

--- a/CRM/Certificate/Test/Helper/Membership.php
+++ b/CRM/Certificate/Test/Helper/Membership.php
@@ -14,6 +14,8 @@ trait CRM_Certificate_Test_Helper_Membership {
       'contact_id' => $contact['id'],
       'membership_type_id' => $membershipType["id"],
       'status_id'  => $membershipStatus["id"],
+      'start_date' => date('Y-m-d', strtotime('-1 month')),
+      'end_date' => date('Y-m-d', strtotime('+1 year')),
     ], $params);
 
     $membership = CRM_Certificate_Test_Fabricator_Membership::fabricate($params);

--- a/CRM/Certificate/Token/Membership.php
+++ b/CRM/Certificate/Token/Membership.php
@@ -120,12 +120,14 @@ class CRM_Certificate_Token_Membership extends CRM_Certificate_Token_AbstractCer
    * @return array
    */
   private function getMembership($membershipId, $contactId, $certificate) {
-    $result = civicrm_api3('Membership', 'getsingle', [
-      'id' => $membershipId,
-      'contact_id' => $contactId,
-    ]);
+    $result = \Civi\Api4\Membership::get(FALSE)
+      ->addSelect('*')
+      ->addWhere('id', '=', $membershipId)
+      ->addWhere('contact_id', '=', $contactId)
+      ->execute()
+      ->first();
 
-    if (!empty($result['is_error'])) {
+    if (empty($result)) {
       return [];
     }
 
@@ -133,6 +135,7 @@ class CRM_Certificate_Token_Membership extends CRM_Certificate_Token_AbstractCer
     $type = CRM_Member_BAO_MembershipType::getMembershipType($result['membership_type_id']);
     $result['status_idlabel'] = $status['membership_status'] ?? '';
     $result['membership_type_idlabel'] = $type['name'] ?? '';
+    $result['membership_name'] = $type['name'] ?? '';
     $result['fee'] = CRM_Utils_Money::format($type['minimum_fee'] ?? '');
     $insuranceTokens = ['insurance_premium_ex_ipt', 'insurance_premium_inc_ipt', 'insurance_premium_ipt_only'];
 

--- a/tests/phpunit/CRM/Certificate/Api/Wrapper/CompuCertificateFilterTest.php
+++ b/tests/phpunit/CRM/Certificate/Api/Wrapper/CompuCertificateFilterTest.php
@@ -132,6 +132,8 @@ class CRM_Certificate_Api_Wrapper_CompuCertificateFilterTest extends BaseHeadles
       'contact_id' => $organisationId,
       'membership_type_id' => $this->membershipType['id'],
       'status_id' => $this->membershipStatus['id'],
+      'start_date' => date('Y-m-d', strtotime('-1 month')),
+      'end_date' => date('Y-m-d', strtotime('+1 year')),
     ]);
   }
 

--- a/tests/phpunit/CRM/Certificate/Entity/MembershipTest.php
+++ b/tests/phpunit/CRM/Certificate/Entity/MembershipTest.php
@@ -324,6 +324,29 @@ class CRM_Certificate_Entity_MembershipTest extends BaseHeadlessTest {
     $this->assertEquals(count($avaliableCertificates) > 0, $valid);
   }
 
+  /**
+   * Returns no configuration for a membership outside the validity window.
+   */
+  public function testCertificateConfigurationExcludesMembershipOutsideValidityWindow() {
+    $contact = CRM_Certificate_Test_Fabricator_Contact::fabricate();
+    $membership = $this->createMembership([
+      'contact_id' => $contact['id'],
+      'start_date' => $this->getDate('-3 years'),
+      'end_date'   => $this->getDate('-2 years'),
+    ]);
+    $this->createMembershipCertificate([
+      'linked_to' => [$membership['membership_type_id']],
+      'statuses'  => [$membership['status_id']],
+      'min_valid_from_date'    => $this->getDate('0 days'),
+      'max_valid_through_date' => $this->getDate('+1 year'),
+    ]);
+
+    $entity = new CRM_Certificate_Entity_Membership();
+    $configuration = $entity->getCertificateConfiguration($membership['id'], $contact['id']);
+
+    $this->assertFalse($configuration);
+  }
+
   private function createCertificate($values) {
     $values['type'] = CRM_Certificate_Enum_CertificateType::MEMBERSHIPS;
     $values['name'] = md5(mt_rand());

--- a/tests/phpunit/api/v3/CompuCertificate/GetcontactcertificatesTest.php
+++ b/tests/phpunit/api/v3/CompuCertificate/GetcontactcertificatesTest.php
@@ -240,6 +240,100 @@ class api_v3_CompuCertificate_GetcontactcertificatesTest extends BaseHeadlessTes
     $this->assertEquals($results['count'] > 0, $valid);
   }
 
+  /**
+   * Membership ending before the certificate's Min Valid From date should not
+   * appear in the API result, even when its status and type otherwise match.
+   */
+  public function testMembershipEndingBeforeMinValidFromDateIsExcluded() {
+    $membership = $this->createMembership([
+      'start_date' => $this->getDate('-2 years'),
+      'end_date'   => $this->getDate('-1 year'),
+    ]);
+    $this->createMembershipCertificate([
+      'linked_to' => [$membership['membership_type_id']],
+      'statuses'  => [$membership['status_id']],
+      'min_valid_from_date'    => $this->getDate('0 days'),
+      'max_valid_through_date' => $this->getDate('+1 year'),
+    ]);
+
+    $results = $this->callApiSuccess('CompuCertificate', 'getcontactcertificates', [
+      'entity'     => 'membership',
+      'contact_id' => $membership['contact']['id'],
+    ]);
+
+    $this->assertEquals(0, $results['count']);
+  }
+
+  /**
+   * Membership starting after the certificate's Max Valid Through date should
+   * not appear in the API result.
+   */
+  public function testMembershipStartingAfterMaxValidThroughDateIsExcluded() {
+    $membership = $this->createMembership([
+      'start_date' => $this->getDate('+2 years'),
+      'end_date'   => $this->getDate('+3 years'),
+    ]);
+    $this->createMembershipCertificate([
+      'linked_to' => [$membership['membership_type_id']],
+      'statuses'  => [$membership['status_id']],
+      'min_valid_from_date'    => $this->getDate('0 days'),
+      'max_valid_through_date' => $this->getDate('+1 year'),
+    ]);
+
+    $results = $this->callApiSuccess('CompuCertificate', 'getcontactcertificates', [
+      'entity'     => 'membership',
+      'contact_id' => $membership['contact']['id'],
+    ]);
+
+    $this->assertEquals(0, $results['count']);
+  }
+
+  /**
+   * Regression test for MMMM-190.
+   *
+   * Contact has two memberships of the same type — one whose dates overlap
+   * the certificate window and one whose dates do not. Only the overlapping
+   * membership should be returned by the API, so the listing does not display
+   * a stale status pulled from a long-expired duplicate membership.
+   */
+  public function testOnlyMembershipWithOverlappingDatesIsReturnedWhenDuplicateExists() {
+    $membershipType = CRM_Certificate_Test_Fabricator_MembershipType::fabricate(['is_active' => 1]);
+    $membershipStatus = CRM_Certificate_Test_Fabricator_MembershipStatus::fabricate(['is_active' => 1]);
+    $contact = CRM_Certificate_Test_Fabricator_Contact::fabricate();
+
+    $validMembership = CRM_Certificate_Test_Fabricator_Membership::fabricate([
+      'contact_id'         => $contact['id'],
+      'membership_type_id' => $membershipType['id'],
+      'status_id'          => $membershipStatus['id'],
+      'start_date'         => $this->getDate('-1 month'),
+      'end_date'           => $this->getDate('+1 year'),
+    ]);
+
+    $staleMembership = CRM_Certificate_Test_Fabricator_Membership::fabricate([
+      'contact_id'         => $contact['id'],
+      'membership_type_id' => $membershipType['id'],
+      'status_id'          => $membershipStatus['id'],
+      'start_date'         => $this->getDate('-3 years'),
+      'end_date'           => $this->getDate('-2 years'),
+    ]);
+
+    $this->createMembershipCertificate([
+      'linked_to' => [$membershipType['id']],
+      'statuses'  => [$membershipStatus['id']],
+      'min_valid_from_date'    => $this->getDate('-2 months'),
+      'max_valid_through_date' => $this->getDate('+2 years'),
+    ]);
+
+    $results = $this->callApiSuccess('CompuCertificate', 'getcontactcertificates', [
+      'entity'     => 'membership',
+      'contact_id' => $contact['id'],
+    ]);
+
+    $returnedMembershipIds = array_column($results['values'], 'membership_id');
+    $this->assertContains($validMembership['id'], $returnedMembershipIds);
+    $this->assertNotContains($staleMembership['id'], $returnedMembershipIds);
+  }
+
   public function tearDown(): void {
     $this->unregisterCurrentLoggedInContactFromSession();
     parent::tearDown();

--- a/tests/phpunit/api/v3/CompuCertificate/GetrelationshipcertificatesTest.php
+++ b/tests/phpunit/api/v3/CompuCertificate/GetrelationshipcertificatesTest.php
@@ -134,6 +134,58 @@ class api_v3_CompuCertificate_GetrelatedcontactcertificatesTest extends BaseHead
     $this->assertEquals($membership['id'], $results['values'][0]['membership_id']);
   }
 
+  /**
+   * Excludes a related membership that is outside the validity window.
+   */
+  public function testRelatedMembershipOutsideCertificateWindowIsExcluded() {
+    $relationshipType = RelationshipTypeFabricator::fabricate([
+      'name_a_b' => 'A Employee of',
+      'name_b_a' => 'A Employer of',
+    ]);
+    $contactA = ContactFabricator::fabricate();
+    $contactB = ContactFabricator::fabricate();
+    RelationshipFabricator::fabricate([
+      'contact_id_a' => $contactA['id'],
+      'contact_id_b' => $contactB['id'],
+      'relationship_type_id' => $relationshipType['id'],
+    ]);
+
+    $membershipType = CRM_Certificate_Test_Fabricator_MembershipType::fabricate(['is_active' => 1]);
+    $membershipStatus = CRM_Certificate_Test_Fabricator_MembershipStatus::fabricate(['is_active' => 1]);
+
+    $withinWindow = CRM_Certificate_Test_Fabricator_Membership::fabricate([
+      'contact_id' => $contactB['id'],
+      'membership_type_id' => $membershipType['id'],
+      'status_id' => $membershipStatus['id'],
+      'start_date' => $this->getDate('-1 month'),
+      'end_date' => $this->getDate('+1 year'),
+    ]);
+    $outsideWindow = CRM_Certificate_Test_Fabricator_Membership::fabricate([
+      'contact_id' => $contactB['id'],
+      'membership_type_id' => $membershipType['id'],
+      'status_id' => $membershipStatus['id'],
+      'start_date' => $this->getDate('-3 years'),
+      'end_date' => $this->getDate('-2 years'),
+    ]);
+
+    $this->createMembershipCertificate([
+      'linked_to' => [$membershipType['id']],
+      'statuses' => [$membershipStatus['id']],
+      'relationship_types' => [$relationshipType['id']],
+      'min_valid_from_date' => $this->getDate('-2 months'),
+      'max_valid_through_date' => $this->getDate('+2 years'),
+    ]);
+
+    $results = $this->callApiSuccess('CompuCertificate', 'getrelationshipcertificates', [
+      'entity' => 'membership',
+      'contact_id' => $contactA['id'],
+    ]);
+
+    $returnedMembershipIds = array_column($results['values'], 'membership_id');
+    $this->assertContains($withinWindow['id'], $returnedMembershipIds);
+    $this->assertNotContains($outsideWindow['id'], $returnedMembershipIds);
+  }
+
   public function tearDown(): void {
     $this->unregisterCurrentLoggedInContactFromSession();
     parent::tearDown();


### PR DESCRIPTION
## Overview
The `CompuCertificate.getcontactcertificates` API was returning every membership matching the certificate's configured types and statuses, ignoring the certificate's `Min Valid From Date` and `Max Valid Through Date` constraints. This let long-expired memberships surface in the SSP certificate listing alongside the contact's active membership of the same type, and the listing then displayed the wrong status.

## Before
<img width="613" height="227" alt="image" src="https://github.com/user-attachments/assets/95fbeba4-1c76-4436-bd92-d9297d615e52" />


## After
<img width="1871" height="886" alt="image" src="https://github.com/user-attachments/assets/806ece4a-c7ef-41af-8ed3-f707f2b2b65d" />

<img width="1402" height="727" alt="image" src="https://github.com/user-attachments/assets/7b7d8292-0ab6-4853-a2b8-44fcb60d69b7" />


## Technical Details
`CRM_Certificate_Entity_Membership::formatConfiguredCertificatesForContact` now skips memberships whose dates do not overlap the certificate's validity window:

- membership `end_date` must be on or after `min_valid_from_date`,
- membership `start_date` must be on or before `max_valid_through_date`,
- either bound being `NULL` is treated as unbounded.

This mirrors the overlap rule already applied for download access in `isCertificateValidForAnEntity`, so the listing and the download check stay consistent.

Three new tests cover the new filter:

- a membership ending before `min_valid_from_date` is excluded,
- a membership starting after `max_valid_through_date` is excluded,
- when a contact has two memberships of the same type, only the one whose dates overlap the certificate is returned (regression test for MMMM-190).

---

## Update — relationship path & download access

Post-QA review surfaced two cases the listing filter above did not cover:

1. **SSP "Organisations" certificate listing (relationship access)** — when a related contact viewed an organisation's certificates, the `Min Valid From` / `Max Valid Through` dates were not applied, so certificates showed for every membership record regardless of its dates.
2. **Certificate download / "Print Certificate"** — the access check evaluated the window against an aggregate of all the contact's memberships, so an out-of-window membership's certificate stayed downloadable.

### Before
<img width="1365" height="692" alt="image" src="https://github.com/user-attachments/assets/0d22bdf2-7b56-4848-9f4b-2ae7025d63d1" />


### After
<img width="1302" height="820" alt="image" src="https://github.com/user-attachments/assets/f3f1cec7-4974-44d9-8432-ff85ab663663" />

### Technical Details
- `CRM_Certificate_BAO_CompuCertificate::getRelationshipEntityCertificates` was not selecting `min_valid_from_date` / `max_valid_through_date`, so on the relationship path the overlap filter received empty bounds and passed every membership. The query now selects both columns.
- `CRM_Certificate_Entity_Membership::isCertificateValidForAnEntity` now validates the specific requested membership against the certificate window, instead of an aggregated min/max across all of the contact's memberships. The overlap check is shared with the listing filter as one helper.

Two further regression tests:

- a related contact's membership outside the certificate window is excluded from the relationship listing,
- `getCertificateConfiguration` returns no configuration for a membership outside the window.


### Additional fix — token render auth

QA also hit `Authorization failed: CiviCRM APIv4 (Membership::get)` on the actual download URL after the validity check passed. `CRM_Certificate_Token_Membership::getMembership`, called during certificate template prefetch, was still using `civicrm_api3('Membership', 'getsingle', ...)` — which delegates to APIv4 with default permission checks and fails for non-admin SSP users. The download endpoint does not catch this exception around the render call, so it surfaced raw. Switched that call to `Civi\Api4\Membership::get(FALSE)` to match the validity-check path.
